### PR TITLE
feature/spo-455-add-sdk-service

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,27 +13,23 @@ concurrency:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
     
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.11'
 
       - name: Cache pip dependencies
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py', 'requirements-test.txt') }}
+          key: pip-${{ runner.os }}-3.11-${{ hashFiles('setup.py', 'requirements-test.txt') }}
           restore-keys: |
-            pip-${{ runner.os }}-${{ matrix.python-version }}-
+            pip-${{ runner.os }}-3.11-
 
       - name: Install dependencies
         run: |
@@ -41,15 +37,6 @@ jobs:
           pip install -e .
           pip install -r requirements-test.txt
 
-      - name: Run tests with coverage
+      - name: Run tests
         run: |
-          pytest tests/ -v --cov=spb_onprem --cov-report=xml --cov-report=term-missing
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        if: matrix.python-version == '3.11'
-        with:
-          file: ./coverage.xml
-          fail_ci_if_error: false
-          verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          pytest tests/ -v --ignore=tests/activities/real_test.py --ignore=tests/exports/real_test.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,55 @@
+name: CI - Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py', 'requirements-test.txt') }}
+          restore-keys: |
+            pip-${{ runner.os }}-${{ matrix.python-version }}-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install -r requirements-test.txt
+
+      - name: Run tests with coverage
+        run: |
+          pytest tests/ -v --cov=spb_onprem --cov-report=xml --cov-report=term-missing
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        if: matrix.python-version == '3.11'
+        with:
+          file: ./coverage.xml
+          fail_ci_if_error: false
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,7 @@
+# Test dependencies for superb-ai-onprem-python SDK
+pytest>=7.0.0
+pytest-cov>=4.0.0
+pytest-mock>=3.10.0
+
+# Additional testing utilities
+coverage>=7.0.0

--- a/spb_onprem/__init__.py
+++ b/spb_onprem/__init__.py
@@ -10,6 +10,8 @@ from .slices.service import SliceService
 from .activities.service import ActivityService
 from .exports.service import ExportService
 from .contents.service import ContentService
+from .predictions.service import PredictionService
+from .models.service import ModelService
 
 # Core Entities and Enums
 from .entities import (
@@ -77,6 +79,8 @@ __all__ = (
     "ActivityService",
     "ExportService",
     "ContentService",
+    "PredictionService",
+    "ModelService",
 
     # Core Entities
     "Data",
@@ -93,6 +97,8 @@ __all__ = (
     "Export",
     "Content",
     "Frame",
+    "PredictionSet",
+    "Model",
     
     # Enums
     "DataType",

--- a/spb_onprem/activities/service.py
+++ b/spb_onprem/activities/service.py
@@ -65,8 +65,7 @@ class ActivityService(BaseService):
                 meta=meta,
             )
         )
-        activity_dict = response
-        return Activity.model_validate(activity_dict)
+        return Activity.model_validate(response)
     
     def get_activities(
         self,
@@ -95,7 +94,7 @@ class ActivityService(BaseService):
                 length=length,
             )
         )
-        activities_dict = response.get("jobs", [])
+        activities_dict = response.get("activities", [])
         return (
             [Activity.model_validate(activity_dict) for activity_dict in activities_dict],
             response.get("next"),

--- a/spb_onprem/activities/service.py
+++ b/spb_onprem/activities/service.py
@@ -94,7 +94,7 @@ class ActivityService(BaseService):
                 length=length,
             )
         )
-        activities_dict = response.get("activities", [])
+        activities_dict = response.get("jobs", [])
         return (
             [Activity.model_validate(activity_dict) for activity_dict in activities_dict],
             response.get("next"),

--- a/spb_onprem/contents/params/__init__.py
+++ b/spb_onprem/contents/params/__init__.py
@@ -1,8 +1,10 @@
 
 from .create import create_variables
 from .get_download_url import get_download_url_params
+from .delete_content import delete_content_params
 
 __all__ = (
     "create_variables",
     "get_download_url_params",
+    "delete_content_params",
 )

--- a/spb_onprem/contents/params/delete_content.py
+++ b/spb_onprem/contents/params/delete_content.py
@@ -1,0 +1,10 @@
+def delete_content_params(content_id: str):
+    """Generate variables for delete content GraphQL mutation.
+    
+    Args:
+        content_id (str): The ID of the content to delete.
+        
+    Returns:
+        dict: Variables dictionary for the GraphQL query.
+    """
+    return {"id": content_id}

--- a/spb_onprem/contents/queries.py
+++ b/spb_onprem/contents/queries.py
@@ -1,6 +1,7 @@
 from .params import (
     create_variables,
     get_download_url_params,
+    delete_content_params,
 )
 
 class Queries:
@@ -32,4 +33,14 @@ class Queries:
             }
         ''',
         "variables": get_download_url_params
+    }
+    
+    DELETE = {
+        "name": "deleteContent",
+        "query": '''
+            mutation DeleteContent($id: String!) {
+                deleteContent(id: $id)
+            }
+        ''',
+        "variables": delete_content_params
     }

--- a/spb_onprem/contents/queries.py
+++ b/spb_onprem/contents/queries.py
@@ -38,7 +38,7 @@ class Queries:
     DELETE = {
         "name": "deleteContent",
         "query": '''
-            mutation DeleteContent($id: String!) {
+            mutation DeleteContent($id: ID!) {
                 deleteContent(id: $id)
             }
         ''',

--- a/spb_onprem/contents/service.py
+++ b/spb_onprem/contents/service.py
@@ -176,3 +176,22 @@ class ContentService(BaseService):
             variables=Queries.GET_DOWNLOAD_URL["variables"](content_id)
         )
         return response
+
+    def delete_content(
+        self,
+        content_id: str,
+    ) -> bool:
+        '''
+        Delete a content by ID.
+        
+        Args:
+            content_id (str): The ID of the content to delete.
+            
+        Returns:
+            bool: True if deletion was successful.
+        '''
+        response = self.request_gql(
+            query=Queries.DELETE,
+            variables=Queries.DELETE["variables"](content_id)
+        )
+        return response.get("deleteContent", False)

--- a/spb_onprem/data/entities/frame.py
+++ b/spb_onprem/data/entities/frame.py
@@ -12,7 +12,7 @@ class Frame(CustomBaseModel):
     The frame of the data.
     Frame is the representation of a single frame in a sequence of data, such as a video or time series.
     """
-    id: str
+    id: Optional[str] = None
     index: Optional[int] = None
     captured_at: Optional[str] = Field(None, alias="capturedAt")
     geo_location: Optional[GeoLocation] = Field(None, alias="geoLocation")

--- a/spb_onprem/data/params/__init__.py
+++ b/spb_onprem/data/params/__init__.py
@@ -18,6 +18,9 @@ from .data_list import (
 from .get_data_detail import (
     get_data_detail_params,
 )
+from .get_evaluation_value_list import (
+    get_evaluation_value_list_params,
+)
 from .remove_data_from_slice import (
     remove_data_from_slice_params
 )
@@ -77,6 +80,7 @@ __all__ = [
     "get_data_id_list_params",
     "get_data_list_params",
     "get_data_detail_params",
+    "get_evaluation_value_list_params",
     "AnnotationFilter",
     "AnnotationRangeFilter",
     "DataFilterOptions",

--- a/spb_onprem/data/params/__init__.py
+++ b/spb_onprem/data/params/__init__.py
@@ -15,6 +15,9 @@ from .data_list import (
     DataFilterOptions,
     DataListFilter,
 )
+from .get_data_detail import (
+    get_data_detail_params,
+)
 from .remove_data_from_slice import (
     remove_data_from_slice_params
 )
@@ -73,6 +76,7 @@ __all__ = [
     "get_params",
     "get_data_id_list_params",
     "get_data_list_params",
+    "get_data_detail_params",
     "AnnotationFilter",
     "AnnotationRangeFilter",
     "DataFilterOptions",

--- a/spb_onprem/data/params/get_data_detail.py
+++ b/spb_onprem/data/params/get_data_detail.py
@@ -1,0 +1,14 @@
+def get_data_detail_params(dataset_id: str, data_id: str):
+    """Generate variables for get data detail GraphQL query.
+    
+    Args:
+        dataset_id (str): The ID of the dataset.
+        data_id (str): The ID of the data.
+        
+    Returns:
+        dict: Variables dictionary for the GraphQL query.
+    """
+    return {
+        "datasetId": dataset_id,
+        "id": data_id
+    }

--- a/spb_onprem/data/params/get_evaluation_value_list.py
+++ b/spb_onprem/data/params/get_evaluation_value_list.py
@@ -1,0 +1,32 @@
+def get_evaluation_value_list_params(
+    dataset_id: str,
+    prediction_set_id: str,
+    filter: dict = None,
+    length: int = 50,
+    cursor: str = None
+):
+    """Generate variables for get evaluation value list GraphQL query.
+    
+    Args:
+        dataset_id (str): The ID of the dataset.
+        prediction_set_id (str): The ID of the prediction set.
+        filter (dict, optional): Diagnosis filter for evaluation values.
+        length (int): Number of items to retrieve per page.
+        cursor (str, optional): Cursor for pagination.
+        
+    Returns:
+        dict: Variables dictionary for the GraphQL query.
+    """
+    params = {
+        "datasetId": dataset_id,
+        "predictionSetId": prediction_set_id,
+        "length": length
+    }
+    
+    if filter is not None:
+        params["filter"] = filter
+        
+    if cursor is not None:
+        params["cursor"] = cursor
+        
+    return params

--- a/spb_onprem/data/params/get_evaluation_value_list.py
+++ b/spb_onprem/data/params/get_evaluation_value_list.py
@@ -1,18 +1,22 @@
+from typing import Union
+from spb_onprem.base_types import UndefinedType, Undefined
+
+
 def get_evaluation_value_list_params(
     dataset_id: str,
     prediction_set_id: str,
-    filter: dict = None,
+    filter: Union[UndefinedType, dict] = Undefined,
     length: int = 50,
-    cursor: str = None
+    cursor: Union[UndefinedType, str] = Undefined
 ):
     """Generate variables for get evaluation value list GraphQL query.
     
     Args:
         dataset_id (str): The ID of the dataset.
         prediction_set_id (str): The ID of the prediction set.
-        filter (dict, optional): Diagnosis filter for evaluation values.
+        filter (Union[UndefinedType, dict], optional): Diagnosis filter for evaluation values.
         length (int): Number of items to retrieve per page.
-        cursor (str, optional): Cursor for pagination.
+        cursor (Union[UndefinedType, str], optional): Cursor for pagination.
         
     Returns:
         dict: Variables dictionary for the GraphQL query.
@@ -23,10 +27,10 @@ def get_evaluation_value_list_params(
         "length": length
     }
     
-    if filter is not None:
+    if filter is not Undefined:
         params["filter"] = filter
         
-    if cursor is not None:
+    if cursor is not Undefined:
         params["cursor"] = cursor
         
     return params

--- a/spb_onprem/data/queries.py
+++ b/spb_onprem/data/queries.py
@@ -5,6 +5,7 @@ from .params import (
     get_data_id_list_params,
     get_data_list_params,
     get_data_detail_params,
+    get_evaluation_value_list_params,
     remove_data_from_slice_params,
     insert_data_to_slice_params,
     delete_data_params,
@@ -634,4 +635,32 @@ class Queries():
             }}
         ''',
         "variables": get_data_detail_params
+    }
+    
+    GET_EVALUATION_VALUE_LIST = {
+        "name": "getEvaluationValueList",
+        "query": '''
+            query GetEvaluationValueList(
+                $datasetId: String!,
+                $predictionSetId: String!,
+                $filter: DiagnosisFilter,
+                $length: Int,
+                $cursor: String
+            ) {
+                evaluationValueList(
+                    datasetId: $datasetId,
+                    predictionSetId: $predictionSetId,
+                    filter: $filter,
+                    length: $length,
+                    cursor: $cursor
+                ) {
+                    totalCount
+                    next
+                    data {
+                        dataId
+                    }
+                }
+            }
+        ''',
+        "variables": get_evaluation_value_list_params
     }

--- a/spb_onprem/data/queries.py
+++ b/spb_onprem/data/queries.py
@@ -4,6 +4,7 @@ from .params import (
     get_params,
     get_data_id_list_params,
     get_data_list_params,
+    get_data_detail_params,
     remove_data_from_slice_params,
     insert_data_to_slice_params,
     delete_data_params,
@@ -105,6 +106,34 @@ class Schemas:
         data {{
             {DATA}  
         }}
+    '''
+    
+    DATA_DETAIL = '''
+        id
+        datasetId
+        scene {
+            id
+            content {
+                id
+            }
+        }
+        annotation {
+            versions {
+                id
+                content {
+                    id
+                }
+            }
+        }
+        predictions {
+            id
+            content {
+                id
+            }
+        }
+        thumbnail {
+            id
+        }
     '''
 
 
@@ -593,4 +622,16 @@ class Queries():
             }}
         ''',
         "variables": update_frames_params,
+    }
+    
+    GET_DETAIL = {
+        "name": "getDataDetail",
+        "query": f'''
+            query GetDataDetail($datasetId: String!, $id: String!) {{
+                data(datasetId: $datasetId, id: $id) {{
+                    {Schemas.DATA_DETAIL}
+                }}
+            }}
+        ''',
+        "variables": get_data_detail_params
     }

--- a/spb_onprem/data/service.py
+++ b/spb_onprem/data/service.py
@@ -868,3 +868,66 @@ class DataService(BaseService):
         )
         data_dict = response.get("data", {})
         return Data.model_validate(data_dict)
+    
+    def get_evaluation_value_list(
+        self,
+        dataset_id: str,
+        prediction_set_id: str,
+        filter: Optional[dict] = None,
+        length: int = 50,
+        cursor: Optional[str] = None
+    ) -> dict:
+        """Get evaluation values list for diagnosis filtering.
+        
+        Retrieves evaluation values for diagnosis filtering with pagination support.
+        
+        Args:
+            dataset_id (str): The dataset ID.
+            prediction_set_id (str): The prediction set ID.
+            filter (Optional[dict]): Diagnosis filter for evaluation values.
+            length (int): Number of items to retrieve per page.
+            cursor (Optional[str]): Cursor for pagination.
+        
+        Returns:
+            dict: Response containing totalCount, next cursor, and data list with dataId fields.
+        """
+        if dataset_id is None:
+            raise BadParameterError("dataset_id is required.")
+        if prediction_set_id is None:
+            raise BadParameterError("prediction_set_id is required.")
+
+        response = self.request_gql(
+            Queries.GET_EVALUATION_VALUE_LIST,
+            Queries.GET_EVALUATION_VALUE_LIST["variables"](
+                dataset_id=dataset_id,
+                prediction_set_id=prediction_set_id,
+                filter=filter,
+                length=length,
+                cursor=cursor
+            )
+        )
+        return response.get("evaluationValueList", {})
+    
+    def get_total_data_id_count_in_evaluation_value(
+        self,
+        dataset_id: str,
+        prediction_set_id: str,
+        filter: Optional[dict] = None
+    ) -> int:
+        """Get total count of data IDs in evaluation values for diagnosis filtering.
+        
+        Args:
+            dataset_id (str): The dataset ID.
+            prediction_set_id (str): The prediction set ID.
+            filter (Optional[dict]): Diagnosis filter for evaluation values.
+        
+        Returns:
+            int: Total count of evaluation values.
+        """
+        result = self.get_evaluation_value_list(
+            dataset_id=dataset_id,
+            prediction_set_id=prediction_set_id,
+            filter=filter,
+            length=1
+        )
+        return result.get("totalCount", 0)

--- a/spb_onprem/data/service.py
+++ b/spb_onprem/data/service.py
@@ -806,9 +806,9 @@ class DataService(BaseService):
         self,
         dataset_id: str,
         prediction_set_id: str,
-        filter: Optional[dict] = None,
+        filter: Union[UndefinedType, dict] = Undefined,
         length: int = 50,
-        cursor: Optional[str] = None
+        cursor: Union[UndefinedType, str] = Undefined
     ) -> dict:
         """Get evaluation values list for diagnosis filtering.
         
@@ -817,9 +817,9 @@ class DataService(BaseService):
         Args:
             dataset_id (str): The dataset ID.
             prediction_set_id (str): The prediction set ID.
-            filter (Optional[dict]): Diagnosis filter for evaluation values.
+            filter (Union[UndefinedType, dict]): Diagnosis filter for evaluation values.
             length (int): Number of items to retrieve per page.
-            cursor (Optional[str]): Cursor for pagination.
+            cursor (Union[UndefinedType, str]): Cursor for pagination.
         
         Returns:
             dict: Response containing totalCount, next cursor, and data list with dataId fields.
@@ -845,14 +845,14 @@ class DataService(BaseService):
         self,
         dataset_id: str,
         prediction_set_id: str,
-        filter: Optional[dict] = None
+        filter: Union[UndefinedType, dict] = Undefined
     ) -> int:
         """Get total count of data IDs in evaluation values for diagnosis filtering.
         
         Args:
             dataset_id (str): The dataset ID.
             prediction_set_id (str): The prediction set ID.
-            filter (Optional[dict]): Diagnosis filter for evaluation values.
+            filter (Union[UndefinedType, dict]): Diagnosis filter for evaluation values.
         
         Returns:
             int: Total count of evaluation values.

--- a/spb_onprem/data/service.py
+++ b/spb_onprem/data/service.py
@@ -836,3 +836,35 @@ class DataService(BaseService):
         )
         data = Data.model_validate(response)
         return data
+
+    def get_data_detail(
+        self,
+        dataset_id: str,
+        data_id: str,
+    ) -> Data:
+        """Get detailed data information including all nested relationships.
+        
+        This method retrieves comprehensive data information including:
+        - Scene content references
+        - Annotation versions with content references
+        - Predictions with content references
+        - Thumbnail references
+        
+        Args:
+            dataset_id (str): The dataset ID.
+            data_id (str): The data ID.
+        
+        Returns:
+            Data: The data object with all nested relationships.
+        """
+        if dataset_id is None:
+            raise BadParameterError("dataset_id is required.")
+        if data_id is None:
+            raise BadParameterError("data_id is required.")
+
+        response = self.request_gql(
+            Queries.GET_DETAIL,
+            Queries.GET_DETAIL["variables"](dataset_id, data_id)
+        )
+        data_dict = response.get("data", {})
+        return Data.model_validate(data_dict)

--- a/spb_onprem/datasets/params/__init__.py
+++ b/spb_onprem/datasets/params/__init__.py
@@ -2,10 +2,12 @@ from .dataset import dataset_params
 from .datasets import datasets_params
 from .create_dataset import create_dataset_params
 from .update_dataset import update_dataset_params
+from .delete_dataset import delete_dataset_params
 
 __all__ = (
     "dataset_params",
     "datasets_params",
     "create_dataset_params",
     "update_dataset_params",
+    "delete_dataset_params",
 )

--- a/spb_onprem/datasets/params/delete_dataset.py
+++ b/spb_onprem/datasets/params/delete_dataset.py
@@ -1,0 +1,12 @@
+def delete_dataset_params(dataset_id: str):
+    """Generate variables for delete dataset GraphQL mutation.
+    
+    Args:
+        dataset_id (str): The ID of the dataset to delete.
+        
+    Returns:
+        dict: Variables dictionary for the GraphQL mutation.
+    """
+    return {
+        "dataset_id": dataset_id
+    }

--- a/spb_onprem/datasets/queries.py
+++ b/spb_onprem/datasets/queries.py
@@ -3,6 +3,7 @@ from spb_onprem.datasets.params import (
     datasets_params,
     create_dataset_params,
     update_dataset_params,
+    delete_dataset_params,
 )
 
 class Schemas:
@@ -76,4 +77,14 @@ class Queries():
             }}
         ''',
         "variables": update_dataset_params,
+    }
+    
+    DELETE_DATASET = {
+        "name": "deleteDataset",
+        "query": '''
+            mutation DeleteDataset($dataset_id: String!) {
+                deleteDataset(datasetId: $dataset_id)
+            }
+        ''',
+        "variables": delete_dataset_params,
     }

--- a/spb_onprem/datasets/service.py
+++ b/spb_onprem/datasets/service.py
@@ -130,3 +130,21 @@ class DatasetService(BaseService):
             ),
         )
         return Dataset.model_validate(response)
+    
+    def delete_dataset(self, dataset_id: str) -> bool:
+        """Delete the dataset.
+        
+        Args:
+            dataset_id (str): The ID of the dataset to delete.
+        
+        Returns:
+            bool: True if deletion was successful.
+        """
+        if dataset_id is None:
+            raise BadParameterError("dataset_id is required.")
+
+        response = self.request_gql(
+            Queries.DELETE_DATASET,
+            Queries.DELETE_DATASET["variables"](dataset_id=dataset_id)
+        )
+        return response.get("deleteDataset", False)

--- a/spb_onprem/entities.py
+++ b/spb_onprem/entities.py
@@ -26,6 +26,8 @@ from .activities.entities import (
 )
 from .exports.entities import Export
 from .contents.entities import Content
+from .predictions.entities import PredictionSet
+from .models.entities import Model
 
 __all__ = [
     # Core Entities
@@ -43,6 +45,8 @@ __all__ = [
     "Export",
     "Content",
     "Frame",
+    "PredictionSet",
+    "Model",
 
     # Enums
     "DataType",

--- a/spb_onprem/models/__init__.py
+++ b/spb_onprem/models/__init__.py
@@ -1,0 +1,7 @@
+from .service import ModelService
+from .entities import Model
+
+__all__ = [
+    "ModelService",
+    "Model",
+]

--- a/spb_onprem/models/entities.py
+++ b/spb_onprem/models/entities.py
@@ -1,0 +1,9 @@
+from typing import Optional
+from spb_onprem.base_model import BaseModel
+
+
+class Model(BaseModel):
+    """Model entity representing a model in the dataset."""
+    
+    id: str
+    name: Optional[str] = None

--- a/spb_onprem/models/params/__init__.py
+++ b/spb_onprem/models/params/__init__.py
@@ -1,0 +1,7 @@
+from .get_models import get_models_params
+from .delete_model import delete_model_params
+
+__all__ = [
+    "get_models_params",
+    "delete_model_params",
+]

--- a/spb_onprem/models/params/delete_model.py
+++ b/spb_onprem/models/params/delete_model.py
@@ -1,0 +1,14 @@
+def delete_model_params(dataset_id: str, model_id: str):
+    """Generate variables for delete model GraphQL mutation.
+    
+    Args:
+        dataset_id (str): The ID of the dataset.
+        model_id (str): The ID of the model to delete.
+        
+    Returns:
+        dict: Variables dictionary for the GraphQL mutation.
+    """
+    return {
+        "dataset_id": dataset_id,
+        "id": model_id
+    }

--- a/spb_onprem/models/params/get_models.py
+++ b/spb_onprem/models/params/get_models.py
@@ -1,0 +1,29 @@
+def get_models_params(
+    dataset_id: str,
+    filter: dict = None,
+    cursor: str = None,
+    length: int = 50
+):
+    """Generate variables for get models GraphQL query.
+    
+    Args:
+        dataset_id (str): The ID of the dataset.
+        filter (dict, optional): Filter for models.
+        cursor (str, optional): Cursor for pagination.
+        length (int): Number of items to retrieve per page.
+        
+    Returns:
+        dict: Variables dictionary for the GraphQL query.
+    """
+    params = {
+        "dataset_id": dataset_id,
+        "length": length
+    }
+    
+    if filter is not None:
+        params["filter"] = filter
+        
+    if cursor is not None:
+        params["cursor"] = cursor
+        
+    return params

--- a/spb_onprem/models/queries.py
+++ b/spb_onprem/models/queries.py
@@ -1,0 +1,33 @@
+from .params import (
+    get_models_params,
+    delete_model_params,
+)
+
+
+class Queries:
+    GET_MODELS = {
+        "name": "getModels",
+        "query": '''
+            query GetModels($dataset_id: String!, $filter: ModelFilter, $cursor: String, $length: Int) {
+                models(datasetId: $dataset_id, filter: $filter, cursor: $cursor, length: $length) {
+                    models {
+                        id
+                        name
+                    }
+                    next
+                    totalCount
+                }
+            }
+        ''',
+        "variables": get_models_params
+    }
+    
+    DELETE_MODEL = {
+        "name": "deleteModel",
+        "query": '''
+            mutation DeleteModel($dataset_id: String!, $id: String!) {
+                deleteModel(datasetId: $dataset_id, id: $id)
+            }
+        ''',
+        "variables": delete_model_params
+    }

--- a/spb_onprem/models/service.py
+++ b/spb_onprem/models/service.py
@@ -1,6 +1,7 @@
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List, Tuple, Union
 
 from spb_onprem.base_service import BaseService
+from spb_onprem.base_types import Undefined, UndefinedType
 from spb_onprem.exceptions import BadParameterError
 from .queries import Queries
 from .entities import Model
@@ -12,20 +13,20 @@ class ModelService(BaseService):
     def get_models(
         self,
         dataset_id: str,
-        filter: Optional[Dict[str, Any]] = None,
-        cursor: Optional[str] = None,
+        filter: Union[UndefinedType, Dict[str, Any]] = Undefined,
+        cursor: Union[UndefinedType, str] = Undefined,
         length: int = 50
-    ) -> Dict[str, Any]:
+    ) -> Tuple[List[Model], Optional[str], int]:
         """Get paginated list of models for a dataset.
         
         Args:
             dataset_id (str): The dataset ID.
-            filter (Optional[Dict[str, Any]]): Filter for models.
-            cursor (Optional[str]): Cursor for pagination.
+            filter (Union[UndefinedType, Dict[str, Any]]): Filter for models.
+            cursor (Union[UndefinedType, str]): Cursor for pagination.
             length (int): Number of items to retrieve per page.
         
         Returns:
-            Dict[str, Any]: Response containing models, next cursor, and totalCount.
+            Tuple[List[Model], Optional[str], int]: A tuple containing models, next cursor, and total count.
         """
         if dataset_id is None:
             raise BadParameterError("dataset_id is required.")
@@ -39,7 +40,12 @@ class ModelService(BaseService):
                 length=length
             )
         )
-        return response.get("models", {})
+        models_list = response.get("models", [])
+        return (
+            [Model.model_validate(model) for model in models_list],
+            response.get("next"),
+            response.get("totalCount", 0)
+        )
     
     def delete_model(
         self,

--- a/spb_onprem/models/service.py
+++ b/spb_onprem/models/service.py
@@ -1,0 +1,70 @@
+from typing import Optional, Dict, Any
+
+from spb_onprem.base_service import BaseService
+from spb_onprem.exceptions import BadParameterError
+from .queries import Queries
+from .entities import Model
+
+
+class ModelService(BaseService):
+    """Service class for handling model operations."""
+    
+    def get_models(
+        self,
+        dataset_id: str,
+        filter: Optional[Dict[str, Any]] = None,
+        cursor: Optional[str] = None,
+        length: int = 50
+    ) -> Dict[str, Any]:
+        """Get paginated list of models for a dataset.
+        
+        Args:
+            dataset_id (str): The dataset ID.
+            filter (Optional[Dict[str, Any]]): Filter for models.
+            cursor (Optional[str]): Cursor for pagination.
+            length (int): Number of items to retrieve per page.
+        
+        Returns:
+            Dict[str, Any]: Response containing models, next cursor, and totalCount.
+        """
+        if dataset_id is None:
+            raise BadParameterError("dataset_id is required.")
+
+        response = self.request_gql(
+            Queries.GET_MODELS,
+            Queries.GET_MODELS["variables"](
+                dataset_id=dataset_id,
+                filter=filter,
+                cursor=cursor,
+                length=length
+            )
+        )
+        return response.get("models", {})
+    
+    def delete_model(
+        self,
+        dataset_id: str,
+        model_id: str
+    ) -> bool:
+        """Delete a model from the dataset.
+        
+        Args:
+            dataset_id (str): The dataset ID.
+            model_id (str): The model ID to delete.
+        
+        Returns:
+            bool: True if deletion was successful.
+        """
+        if dataset_id is None:
+            raise BadParameterError("dataset_id is required.")
+        if model_id is None:
+            raise BadParameterError("model_id is required.")
+
+        response = self.request_gql(
+            Queries.DELETE_MODEL,
+            Queries.DELETE_MODEL["variables"](
+                dataset_id=dataset_id,
+                model_id=model_id
+            )
+        )
+        return response.get("deleteModel", False)

--- a/spb_onprem/predictions/__init__.py
+++ b/spb_onprem/predictions/__init__.py
@@ -1,0 +1,7 @@
+from .service import PredictionService
+from .entities import PredictionSet
+
+__all__ = [
+    "PredictionService",
+    "PredictionSet",
+]

--- a/spb_onprem/predictions/entities.py
+++ b/spb_onprem/predictions/entities.py
@@ -1,19 +1,11 @@
 from typing import List, Optional
-from spb_onprem.base_model import BaseModel
+from spb_onprem.base_model import CustomBaseModel, Field
 
 
-class PredictionSet(BaseModel):
+class PredictionSet(CustomBaseModel):
     """PredictionSet entity representing a set of predictions in the dataset."""
     
     id: str
     name: Optional[str] = None
-    annotations_contents: Optional[List[str]] = None
-    evaluation_result_content: Optional[dict] = None
-    
-    class Config:
-        populate_by_name = True
-        alias_generator = lambda field_name: (
-            "annotationsContents" if field_name == "annotations_contents"
-            else "evaluationResultContent" if field_name == "evaluation_result_content"
-            else field_name
-        )
+    annotations_contents: Optional[List[str]] = Field(None, alias="annotationsContents")
+    evaluation_result_content: Optional[dict] = Field(None, alias="evaluationResultContent")

--- a/spb_onprem/predictions/entities.py
+++ b/spb_onprem/predictions/entities.py
@@ -1,0 +1,19 @@
+from typing import List, Optional
+from spb_onprem.base_model import BaseModel
+
+
+class PredictionSet(BaseModel):
+    """PredictionSet entity representing a set of predictions in the dataset."""
+    
+    id: str
+    name: Optional[str] = None
+    annotations_contents: Optional[List[str]] = None
+    evaluation_result_content: Optional[dict] = None
+    
+    class Config:
+        populate_by_name = True
+        alias_generator = lambda field_name: (
+            "annotationsContents" if field_name == "annotations_contents"
+            else "evaluationResultContent" if field_name == "evaluation_result_content"
+            else field_name
+        )

--- a/spb_onprem/predictions/params/__init__.py
+++ b/spb_onprem/predictions/params/__init__.py
@@ -1,0 +1,11 @@
+from .get_prediction_sets import get_prediction_sets_params
+from .get_prediction_set import get_prediction_set_params
+from .delete_prediction_set import delete_prediction_set_params
+from .delete_prediction_from_data import delete_prediction_from_data_params
+
+__all__ = [
+    "get_prediction_sets_params",
+    "get_prediction_set_params", 
+    "delete_prediction_set_params",
+    "delete_prediction_from_data_params",
+]

--- a/spb_onprem/predictions/params/delete_prediction_from_data.py
+++ b/spb_onprem/predictions/params/delete_prediction_from_data.py
@@ -1,0 +1,20 @@
+def delete_prediction_from_data_params(
+    dataset_id: str, 
+    data_id: str, 
+    prediction_set_id: str
+):
+    """Generate variables for delete prediction from data GraphQL mutation.
+    
+    Args:
+        dataset_id (str): The ID of the dataset.
+        data_id (str): The ID of the data.
+        prediction_set_id (str): The ID of the prediction set.
+        
+    Returns:
+        dict: Variables dictionary for the GraphQL mutation.
+    """
+    return {
+        "dataset_id": dataset_id,
+        "data_id": data_id,
+        "prediction_set_id": prediction_set_id
+    }

--- a/spb_onprem/predictions/params/delete_prediction_set.py
+++ b/spb_onprem/predictions/params/delete_prediction_set.py
@@ -1,0 +1,14 @@
+def delete_prediction_set_params(dataset_id: str, prediction_set_id: str):
+    """Generate variables for delete prediction set GraphQL mutation.
+    
+    Args:
+        dataset_id (str): The ID of the dataset.
+        prediction_set_id (str): The ID of the prediction set to delete.
+        
+    Returns:
+        dict: Variables dictionary for the GraphQL mutation.
+    """
+    return {
+        "dataset_id": dataset_id,
+        "id": prediction_set_id
+    }

--- a/spb_onprem/predictions/params/get_prediction_set.py
+++ b/spb_onprem/predictions/params/get_prediction_set.py
@@ -1,0 +1,14 @@
+def get_prediction_set_params(dataset_id: str, prediction_set_id: str):
+    """Generate variables for get prediction set GraphQL query.
+    
+    Args:
+        dataset_id (str): The ID of the dataset.
+        prediction_set_id (str): The ID of the prediction set.
+        
+    Returns:
+        dict: Variables dictionary for the GraphQL query.
+    """
+    return {
+        "dataset_id": dataset_id,
+        "id": prediction_set_id
+    }

--- a/spb_onprem/predictions/params/get_prediction_sets.py
+++ b/spb_onprem/predictions/params/get_prediction_sets.py
@@ -1,0 +1,29 @@
+def get_prediction_sets_params(
+    dataset_id: str,
+    filter: dict = None,
+    cursor: str = None,
+    length: int = 50
+):
+    """Generate variables for get prediction sets GraphQL query.
+    
+    Args:
+        dataset_id (str): The ID of the dataset.
+        filter (dict, optional): Filter for prediction sets.
+        cursor (str, optional): Cursor for pagination.
+        length (int): Number of items to retrieve per page.
+        
+    Returns:
+        dict: Variables dictionary for the GraphQL query.
+    """
+    params = {
+        "dataset_id": dataset_id,
+        "length": length
+    }
+    
+    if filter is not None:
+        params["filter"] = filter
+        
+    if cursor is not None:
+        params["cursor"] = cursor
+        
+    return params

--- a/spb_onprem/predictions/queries.py
+++ b/spb_onprem/predictions/queries.py
@@ -54,8 +54,8 @@ class Queries:
     DELETE_PREDICTION_FROM_DATA = {
         "name": "deletePredictionFromData",
         "query": '''
-            mutation RemovePredictionFromData($dataset_id: String!, $data_id: String!, $set_id: String!) {
-                removePredictionFromData(datasetId: $dataset_id, dataId: $data_id, setId: $set_id)
+            mutation DeletePrediction($dataset_id: String!, $data_id: String!, $set_id: String!) {
+                deletePrediction(datasetId: $dataset_id, dataId: $data_id, setId: $set_id)
             }
         ''',
         "variables": delete_prediction_from_data_params

--- a/spb_onprem/predictions/queries.py
+++ b/spb_onprem/predictions/queries.py
@@ -1,0 +1,62 @@
+from .params import (
+    get_prediction_sets_params,
+    get_prediction_set_params,
+    delete_prediction_set_params,
+    delete_prediction_from_data_params,
+)
+
+
+class Queries:
+    GET_PREDICTION_SETS = {
+        "name": "getPredictionSets",
+        "query": '''
+            query GetPredictionSets($dataset_id: String!, $filter: PredictionSetFilter, $cursor: String, $length: Int) {
+                predictionSets(datasetId: $dataset_id, filter: $filter, cursor: $cursor, length: $length) {
+                    predictionSets {
+                        id
+                        name
+                    }
+                    next
+                    totalCount
+                }
+            }
+        ''',
+        "variables": get_prediction_sets_params
+    }
+    
+    GET_PREDICTION_SET = {
+        "name": "getPredictionSet",
+        "query": '''
+            query GetPredictionSet($dataset_id: String!, $id: String!) {
+                predictionSet(datasetId: $dataset_id, id: $id) {
+                    id
+                    name
+                    annotationsContents
+                    evaluationResultContent {
+                        id
+                    }
+                }
+            }
+        ''',
+        "variables": get_prediction_set_params
+    }
+    
+    DELETE_PREDICTION_SET = {
+        "name": "deletePredictionSet",
+        "query": '''
+            mutation DeletePredictionSet($dataset_id: String!, $id: String!) {
+                deletePredictionSet(datasetId: $dataset_id, id: $id)
+            }
+        ''',
+        "variables": delete_prediction_set_params
+    }
+    
+    DELETE_PREDICTION_FROM_DATA = {
+        "name": "deletePredictionFromData",
+        "query": '''
+            mutation RemovePredictionFromData($dataset_id: String!, $data_id: String!, $set_id: String!) {
+                removePredictionFromData(datasetId: $dataset_id, dataId: $data_id, setId: $set_id)
+            }
+        ''',
+        "variables": delete_prediction_from_data_params
+    }

--- a/spb_onprem/predictions/service.py
+++ b/spb_onprem/predictions/service.py
@@ -1,0 +1,132 @@
+from typing import Optional, Dict, Any
+
+from spb_onprem.base_service import BaseService
+from spb_onprem.exceptions import BadParameterError
+from .queries import Queries
+from .entities import PredictionSet
+
+
+class PredictionService(BaseService):
+    """Service class for handling prediction set operations."""
+    
+    def get_prediction_sets(
+        self,
+        dataset_id: str,
+        filter: Optional[Dict[str, Any]] = None,
+        cursor: Optional[str] = None,
+        length: int = 50
+    ) -> Dict[str, Any]:
+        """Get paginated list of prediction sets for a dataset.
+        
+        Args:
+            dataset_id (str): The dataset ID.
+            filter (Optional[Dict[str, Any]]): Filter for prediction sets.
+            cursor (Optional[str]): Cursor for pagination.
+            length (int): Number of items to retrieve per page.
+        
+        Returns:
+            Dict[str, Any]: Response containing predictionSets, next cursor, and totalCount.
+        """
+        if dataset_id is None:
+            raise BadParameterError("dataset_id is required.")
+
+        response = self.request_gql(
+            Queries.GET_PREDICTION_SETS,
+            Queries.GET_PREDICTION_SETS["variables"](
+                dataset_id=dataset_id,
+                filter=filter,
+                cursor=cursor,
+                length=length
+            )
+        )
+        return response.get("predictionSets", {})
+    
+    def get_prediction_set(
+        self,
+        dataset_id: str,
+        prediction_set_id: str
+    ) -> PredictionSet:
+        """Get detailed prediction set information including content IDs.
+        
+        Args:
+            dataset_id (str): The dataset ID.
+            prediction_set_id (str): The prediction set ID.
+        
+        Returns:
+            PredictionSet: The prediction set entity.
+        """
+        if dataset_id is None:
+            raise BadParameterError("dataset_id is required.")
+        if prediction_set_id is None:
+            raise BadParameterError("prediction_set_id is required.")
+
+        response = self.request_gql(
+            Queries.GET_PREDICTION_SET,
+            Queries.GET_PREDICTION_SET["variables"](
+                dataset_id=dataset_id,
+                prediction_set_id=prediction_set_id
+            )
+        )
+        prediction_set_dict = response.get("predictionSet", {})
+        return PredictionSet.model_validate(prediction_set_dict)
+    
+    def delete_prediction_set(
+        self,
+        dataset_id: str,
+        prediction_set_id: str
+    ) -> bool:
+        """Delete a prediction set from the dataset.
+        
+        Args:
+            dataset_id (str): The dataset ID.
+            prediction_set_id (str): The prediction set ID to delete.
+        
+        Returns:
+            bool: True if deletion was successful.
+        """
+        if dataset_id is None:
+            raise BadParameterError("dataset_id is required.")
+        if prediction_set_id is None:
+            raise BadParameterError("prediction_set_id is required.")
+
+        response = self.request_gql(
+            Queries.DELETE_PREDICTION_SET,
+            Queries.DELETE_PREDICTION_SET["variables"](
+                dataset_id=dataset_id,
+                prediction_set_id=prediction_set_id
+            )
+        )
+        return response.get("deletePredictionSet", False)
+    
+    def delete_prediction_from_data(
+        self,
+        dataset_id: str,
+        data_id: str,
+        prediction_set_id: str
+    ) -> bool:
+        """Delete predictions from a specific data item for a given prediction set.
+        
+        Args:
+            dataset_id (str): The dataset ID.
+            data_id (str): The data ID.
+            prediction_set_id (str): The prediction set ID.
+        
+        Returns:
+            bool: True if deletion was successful.
+        """
+        if dataset_id is None:
+            raise BadParameterError("dataset_id is required.")
+        if data_id is None:
+            raise BadParameterError("data_id is required.")
+        if prediction_set_id is None:
+            raise BadParameterError("prediction_set_id is required.")
+
+        response = self.request_gql(
+            Queries.DELETE_PREDICTION_FROM_DATA,
+            Queries.DELETE_PREDICTION_FROM_DATA["variables"](
+                dataset_id=dataset_id,
+                data_id=data_id,
+                prediction_set_id=prediction_set_id
+            )
+        )
+        return response.get("removePredictionFromData", False)

--- a/spb_onprem/predictions/service.py
+++ b/spb_onprem/predictions/service.py
@@ -129,4 +129,4 @@ class PredictionService(BaseService):
                 prediction_set_id=prediction_set_id
             )
         )
-        return response.get("removePredictionFromData", False)
+        return response.get("deletePrediction") is not None

--- a/tests/activities/test_params.py
+++ b/tests/activities/test_params.py
@@ -20,7 +20,7 @@ class TestUpdateActivityHistoryParams:
         )
         
         # Then
-        assert params["activity_history_id"] == activity_history_id
+        assert params["id"] == activity_history_id
         assert params["status"] == status
         assert params["meta"] == meta
         assert "progress" not in params
@@ -37,7 +37,7 @@ class TestUpdateActivityHistoryParams:
         )
         
         # Then
-        assert params["activity_history_id"] == activity_history_id
+        assert params["id"] == activity_history_id
         assert params["progress"] == progress
         assert "status" not in params
         assert "meta" not in params

--- a/tests/activities/test_service.py
+++ b/tests/activities/test_service.py
@@ -15,12 +15,10 @@ class TestActivityService:
     def test_create_activity(self, activity_service):
         # Given
         mock_response = {
-            "createJob": {
-                "id": "test_id",
-                "type": "test_type",
-                "name": "test_name",
-                "description": "test_description"
-            }
+            "id": "test_id",
+            "activity_type": "test_type",
+            "name": "test_name",
+            "description": "test_description"
         }
         activity_service.request_gql = MagicMock(return_value=mock_response)
         
@@ -34,29 +32,27 @@ class TestActivityService:
         # Then
         assert isinstance(activity, Activity)
         assert activity.id == "test_id"
-        assert activity.type == "test_type"
+        assert activity.activity_type == "test_type"
         assert activity.name == "test_name"
         assert activity.description == "test_description"
     
     def test_get_activities(self, activity_service):
         # Given
         mock_response = {
-            "jobs": {
-                "activities": [
-                    {
-                        "id": "test_id_1",
-                        "type": "test_type",
-                        "name": "test_name_1"
-                    },
-                    {
-                        "id": "test_id_2",
-                        "type": "test_type",
-                        "name": "test_name_2"
-                    }
-                ],
-                "next": "next_cursor",
-                "totalCount": 2
-            }
+            "activities": [
+                {
+                    "id": "test_id_1",
+                    "activity_type": "test_type",
+                    "name": "test_name_1"
+                },
+                {
+                    "id": "test_id_2",
+                    "activity_type": "test_type",
+                    "name": "test_name_2"
+                }
+            ],
+            "next": "next_cursor",
+            "totalCount": 2
         }
         activity_service.request_gql = MagicMock(return_value=mock_response)
         
@@ -74,11 +70,9 @@ class TestActivityService:
     def test_start_activity(self, activity_service):
         # Given
         mock_response = {
-            "startJob": {
-                "id": "test_history_id",
-                "jobId": "test_activity_id",
-                "status": ActivityStatus.RUNNING.value
-            }
+            "id": "test_history_id",
+            "jobId": "test_activity_id",
+            "status": ActivityStatus.RUNNING.value
         }
         activity_service.request_gql = MagicMock(return_value=mock_response)
         
@@ -97,11 +91,9 @@ class TestActivityService:
     def test_update_activity_history_status(self, activity_service):
         # Given
         mock_response = {
-            "updateJobHistory": {
-                "id": "test_history_id",
-                "jobId": "test_activity_id",
-                "status": ActivityStatus.SUCCESS.value
-            }
+            "id": "test_history_id",
+            "jobId": "test_activity_id",
+            "status": ActivityStatus.SUCCESS.value
         }
         activity_service.request_gql = MagicMock(return_value=mock_response)
         
@@ -119,11 +111,9 @@ class TestActivityService:
     def test_update_activity_history_progress(self, activity_service):
         # Given
         mock_response = {
-            "updateJobHistory": {
-                "id": "test_history_id",
-                "jobId": "test_activity_id",
-                "progress": {"current": 50, "total": 100}
-            }
+            "id": "test_history_id",
+            "jobId": "test_activity_id",
+            "progress": {"current": 50, "total": 100}
         }
         activity_service.request_gql = MagicMock(return_value=mock_response)
         

--- a/tests/activities/test_service.py
+++ b/tests/activities/test_service.py
@@ -39,7 +39,7 @@ class TestActivityService:
     def test_get_activities(self, activity_service):
         # Given
         mock_response = {
-            "activities": [
+            "jobs": [
                 {
                     "id": "test_id_1",
                     "activity_type": "test_type",

--- a/tests/contents/test_content_service.py
+++ b/tests/contents/test_content_service.py
@@ -1,0 +1,100 @@
+import pytest
+from unittest.mock import Mock, patch
+
+from spb_onprem.contents.service import ContentService
+from spb_onprem.contents.queries import Queries
+
+
+class TestContentService:
+    """Test cases for ContentService with new delete_content method."""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method."""
+        self.content_service = ContentService()
+        self.content_service.request_gql = Mock()
+
+    def test_delete_content_success(self):
+        """Test successful content deletion."""
+        # Arrange
+        content_id = "test-content-123"
+        mock_response = {"deleteContent": True}
+        self.content_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.content_service.delete_content(content_id)
+
+        # Assert
+        assert result is True
+        self.content_service.request_gql.assert_called_once_with(
+            query=Queries.DELETE,
+            variables=Queries.DELETE["variables"](content_id)
+        )
+
+    def test_delete_content_failure(self):
+        """Test content deletion failure."""
+        # Arrange
+        content_id = "nonexistent-content"
+        mock_response = {"deleteContent": False}
+        self.content_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.content_service.delete_content(content_id)
+
+        # Assert
+        assert result is False
+        self.content_service.request_gql.assert_called_once_with(
+            query=Queries.DELETE,
+            variables=Queries.DELETE["variables"](content_id)
+        )
+
+    def test_delete_content_missing_response(self):
+        """Test content deletion with missing response field."""
+        # Arrange
+        content_id = "test-content-456"
+        mock_response = {}  # No deleteContent field
+        self.content_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.content_service.delete_content(content_id)
+
+        # Assert
+        assert result is False
+        self.content_service.request_gql.assert_called_once_with(
+            query=Queries.DELETE,
+            variables=Queries.DELETE["variables"](content_id)
+        )
+
+    def test_delete_content_query_structure(self):
+        """Test that DELETE query has correct structure."""
+        # Arrange & Act
+        query_structure = Queries.DELETE
+
+        # Assert
+        assert query_structure["name"] == "deleteContent"
+        assert "mutation DeleteContent($id: String!)" in query_structure["query"]
+        assert "deleteContent(id: $id)" in query_structure["query"]
+        assert callable(query_structure["variables"])
+
+    def test_delete_content_variables_function(self):
+        """Test that variables function generates correct parameters."""
+        # Arrange
+        content_id = "test-content-789"
+
+        # Act
+        variables = Queries.DELETE["variables"](content_id)
+
+        # Assert
+        assert variables == {"id": content_id}
+
+    @patch('spb_onprem.contents.service.ContentService.request_gql')
+    def test_delete_content_exception_handling(self, mock_request):
+        """Test content deletion exception handling."""
+        # Arrange
+        content_id = "test-content-error"
+        mock_request.side_effect = Exception("Network error")
+
+        # Act & Assert
+        with pytest.raises(Exception, match="Network error"):
+            self.content_service.delete_content(content_id)
+
+        mock_request.assert_called_once()

--- a/tests/contents/test_content_service.py
+++ b/tests/contents/test_content_service.py
@@ -71,7 +71,7 @@ class TestContentService:
 
         # Assert
         assert query_structure["name"] == "deleteContent"
-        assert "mutation DeleteContent($id: String!)" in query_structure["query"]
+        assert "mutation DeleteContent($id: ID!)" in query_structure["query"]
         assert "deleteContent(id: $id)" in query_structure["query"]
         assert callable(query_structure["variables"])
 
@@ -86,15 +86,14 @@ class TestContentService:
         # Assert
         assert variables == {"id": content_id}
 
-    @patch('spb_onprem.contents.service.ContentService.request_gql')
-    def test_delete_content_exception_handling(self, mock_request):
+    def test_delete_content_exception_handling(self):
         """Test content deletion exception handling."""
         # Arrange
         content_id = "test-content-error"
-        mock_request.side_effect = Exception("Network error")
+        self.content_service.request_gql.side_effect = Exception("Network error")
 
         # Act & Assert
         with pytest.raises(Exception, match="Network error"):
             self.content_service.delete_content(content_id)
 
-        mock_request.assert_called_once()
+        self.content_service.request_gql.assert_called_once()

--- a/tests/data/test_data_service.py
+++ b/tests/data/test_data_service.py
@@ -365,8 +365,7 @@ class TestDataService:
                 dataset_id=dataset_id,
                 prediction_set_id=prediction_set_id,
                 filter=filter_dict,
-                length=1,
-                cursor=None
+                length=1
             )
         )
 

--- a/tests/data/test_data_service.py
+++ b/tests/data/test_data_service.py
@@ -200,19 +200,18 @@ class TestDataService:
         assert len(result.predictions) == 1
         assert result.thumbnail.id == "thumbnail-complex"
 
-    @patch('spb_onprem.data.service.DataService.request_gql')
-    def test_get_data_detail_exception_handling(self, mock_request):
+    def test_get_data_detail_exception_handling(self):
         """Test get_data_detail exception handling."""
         # Arrange
         dataset_id = "dataset-error"
         data_id = "data-error"
-        mock_request.side_effect = Exception("GraphQL error")
+        self.data_service.request_gql.side_effect = Exception("GraphQL error")
 
         # Act & Assert
         with pytest.raises(Exception, match="GraphQL error"):
             self.data_service.get_data_detail(dataset_id, data_id)
 
-        mock_request.assert_called_once()
+        self.data_service.request_gql.assert_called_once()
 
     def test_get_evaluation_value_list_success(self):
         """Test successful evaluation value list retrieval."""

--- a/tests/data/test_data_service.py
+++ b/tests/data/test_data_service.py
@@ -1,0 +1,215 @@
+import pytest
+from unittest.mock import Mock, patch
+
+from spb_onprem.data.service import DataService
+from spb_onprem.data.queries import Queries
+from spb_onprem.data.entities import Data
+from spb_onprem.exceptions import BadParameterError
+
+
+class TestDataService:
+    """Test cases for DataService with new get_data_detail method."""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method."""
+        self.data_service = DataService()
+        self.data_service.request_gql = Mock()
+
+    def test_get_data_detail_success(self):
+        """Test successful data detail retrieval."""
+        # Arrange
+        dataset_id = "dataset-123"
+        data_id = "data-456"
+        mock_response = {
+            "data": {
+                "id": data_id,
+                "datasetId": dataset_id,
+                "scene": [
+                    {
+                        "id": "scene-1",
+                        "content": {"id": "content-1"}
+                    }
+                ],
+                "annotation": {
+                    "versions": [
+                        {
+                            "id": "annotation-1",
+                            "content": {"id": "content-2"}
+                        }
+                    ]
+                },
+                "predictions": [
+                    {
+                        "id": "prediction-1",
+                        "content": {"id": "content-3"}
+                    }
+                ],
+                "thumbnail": {
+                    "id": "thumbnail-1"
+                }
+            }
+        }
+        self.data_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.data_service.get_data_detail(dataset_id, data_id)
+
+        # Assert
+        assert isinstance(result, Data)
+        assert result.id == data_id
+        assert result.dataset_id == dataset_id
+        self.data_service.request_gql.assert_called_once_with(
+            Queries.GET_DETAIL,
+            Queries.GET_DETAIL["variables"](dataset_id, data_id)
+        )
+
+    def test_get_data_detail_missing_dataset_id(self):
+        """Test get_data_detail with missing dataset_id."""
+        # Arrange
+        dataset_id = None
+        data_id = "data-456"
+
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="dataset_id is required"):
+            self.data_service.get_data_detail(dataset_id, data_id)
+
+    def test_get_data_detail_missing_data_id(self):
+        """Test get_data_detail with missing data_id."""
+        # Arrange
+        dataset_id = "dataset-123"
+        data_id = None
+
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="data_id is required"):
+            self.data_service.get_data_detail(dataset_id, data_id)
+
+    def test_get_data_detail_empty_response(self):
+        """Test get_data_detail with empty data response."""
+        # Arrange
+        dataset_id = "dataset-123"
+        data_id = "data-456"
+        mock_response = {"data": {}}
+        self.data_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.data_service.get_data_detail(dataset_id, data_id)
+
+        # Assert
+        assert isinstance(result, Data)
+        self.data_service.request_gql.assert_called_once_with(
+            Queries.GET_DETAIL,
+            Queries.GET_DETAIL["variables"](dataset_id, data_id)
+        )
+
+    def test_get_data_detail_missing_data_field(self):
+        """Test get_data_detail with missing data field in response."""
+        # Arrange
+        dataset_id = "dataset-123"
+        data_id = "data-456"
+        mock_response = {}  # No data field
+        self.data_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.data_service.get_data_detail(dataset_id, data_id)
+
+        # Assert
+        assert isinstance(result, Data)
+        self.data_service.request_gql.assert_called_once_with(
+            Queries.GET_DETAIL,
+            Queries.GET_DETAIL["variables"](dataset_id, data_id)
+        )
+
+    def test_get_data_detail_query_structure(self):
+        """Test that GET_DETAIL query has correct structure."""
+        # Arrange & Act
+        query_structure = Queries.GET_DETAIL
+
+        # Assert
+        assert query_structure["name"] == "getDataDetail"
+        assert "query GetDataDetail($datasetId: String!, $id: String!)" in query_structure["query"]
+        assert "data(datasetId: $datasetId, id: $id)" in query_structure["query"]
+        assert callable(query_structure["variables"])
+
+    def test_get_data_detail_variables_function(self):
+        """Test that variables function generates correct parameters."""
+        # Arrange
+        dataset_id = "dataset-789"
+        data_id = "data-101"
+
+        # Act
+        variables = Queries.GET_DETAIL["variables"](dataset_id, data_id)
+
+        # Assert
+        assert variables == {
+            "datasetId": dataset_id,
+            "id": data_id
+        }
+
+    def test_get_data_detail_with_nested_relationships(self):
+        """Test get_data_detail with complex nested relationships."""
+        # Arrange
+        dataset_id = "dataset-complex"
+        data_id = "data-complex"
+        mock_response = {
+            "data": {
+                "id": data_id,
+                "datasetId": dataset_id,
+                "scene": [
+                    {
+                        "id": "scene-1",
+                        "content": {"id": "scene-content-1"}
+                    },
+                    {
+                        "id": "scene-2", 
+                        "content": {"id": "scene-content-2"}
+                    }
+                ],
+                "annotation": {
+                    "versions": [
+                        {
+                            "id": "annotation-v1",
+                            "content": {"id": "annotation-content-1"}
+                        },
+                        {
+                            "id": "annotation-v2",
+                            "content": {"id": "annotation-content-2"}
+                        }
+                    ]
+                },
+                "predictions": [
+                    {
+                        "id": "prediction-1",
+                        "content": {"id": "prediction-content-1"}
+                    }
+                ],
+                "thumbnail": {
+                    "id": "thumbnail-complex"
+                }
+            }
+        }
+        self.data_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.data_service.get_data_detail(dataset_id, data_id)
+
+        # Assert
+        assert isinstance(result, Data)
+        assert result.id == data_id
+        assert len(result.scene) == 2
+        assert len(result.annotation.versions) == 2
+        assert len(result.predictions) == 1
+        assert result.thumbnail.id == "thumbnail-complex"
+
+    @patch('spb_onprem.data.service.DataService.request_gql')
+    def test_get_data_detail_exception_handling(self, mock_request):
+        """Test get_data_detail exception handling."""
+        # Arrange
+        dataset_id = "dataset-error"
+        data_id = "data-error"
+        mock_request.side_effect = Exception("GraphQL error")
+
+        # Act & Assert
+        with pytest.raises(Exception, match="GraphQL error"):
+            self.data_service.get_data_detail(dataset_id, data_id)
+
+        mock_request.assert_called_once()

--- a/tests/data/test_data_service.py
+++ b/tests/data/test_data_service.py
@@ -213,3 +213,202 @@ class TestDataService:
             self.data_service.get_data_detail(dataset_id, data_id)
 
         mock_request.assert_called_once()
+
+    def test_get_evaluation_value_list_success(self):
+        """Test successful evaluation value list retrieval."""
+        # Arrange
+        dataset_id = "dataset-123"
+        prediction_set_id = "pred-set-456"
+        filter_dict = {"score": {"min": 0.8}}
+        length = 25
+        cursor = "cursor-abc"
+        
+        mock_response = {
+            "evaluationValueList": {
+                "totalCount": 100,
+                "next": "cursor-def",
+                "data": [
+                    {"dataId": "data-1"},
+                    {"dataId": "data-2"},
+                    {"dataId": "data-3"}
+                ]
+            }
+        }
+        self.data_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.data_service.get_evaluation_value_list(
+            dataset_id=dataset_id,
+            prediction_set_id=prediction_set_id,
+            filter=filter_dict,
+            length=length,
+            cursor=cursor
+        )
+
+        # Assert
+        expected_result = {
+            "totalCount": 100,
+            "next": "cursor-def",
+            "data": [
+                {"dataId": "data-1"},
+                {"dataId": "data-2"},
+                {"dataId": "data-3"}
+            ]
+        }
+        assert result == expected_result
+        self.data_service.request_gql.assert_called_once_with(
+            Queries.GET_EVALUATION_VALUE_LIST,
+            Queries.GET_EVALUATION_VALUE_LIST["variables"](
+                dataset_id=dataset_id,
+                prediction_set_id=prediction_set_id,
+                filter=filter_dict,
+                length=length,
+                cursor=cursor
+            )
+        )
+
+    def test_get_evaluation_value_list_without_filter(self):
+        """Test evaluation value list retrieval without filter."""
+        # Arrange
+        dataset_id = "dataset-123"
+        prediction_set_id = "pred-set-456"
+        
+        mock_response = {
+            "evaluationValueList": {
+                "totalCount": 50,
+                "next": None,
+                "data": [{"dataId": "data-1"}]
+            }
+        }
+        self.data_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.data_service.get_evaluation_value_list(
+            dataset_id=dataset_id,
+            prediction_set_id=prediction_set_id
+        )
+
+        # Assert
+        assert result["totalCount"] == 50
+        assert result["next"] is None
+        assert len(result["data"]) == 1
+
+    def test_get_evaluation_value_list_missing_dataset_id(self):
+        """Test evaluation value list with missing dataset_id."""
+        # Arrange
+        prediction_set_id = "pred-set-456"
+
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="dataset_id is required"):
+            self.data_service.get_evaluation_value_list(
+                dataset_id=None,
+                prediction_set_id=prediction_set_id
+            )
+
+    def test_get_evaluation_value_list_missing_prediction_set_id(self):
+        """Test evaluation value list with missing prediction_set_id."""
+        # Arrange
+        dataset_id = "dataset-123"
+
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="prediction_set_id is required"):
+            self.data_service.get_evaluation_value_list(
+                dataset_id=dataset_id,
+                prediction_set_id=None
+            )
+
+    def test_get_evaluation_value_list_empty_response(self):
+        """Test evaluation value list with empty response."""
+        # Arrange
+        dataset_id = "dataset-123"
+        prediction_set_id = "pred-set-456"
+        
+        mock_response = {}
+        self.data_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.data_service.get_evaluation_value_list(
+            dataset_id=dataset_id,
+            prediction_set_id=prediction_set_id
+        )
+
+        # Assert
+        assert result == {}
+
+    def test_get_total_data_id_count_in_evaluation_value_success(self):
+        """Test successful total count retrieval."""
+        # Arrange
+        dataset_id = "dataset-123"
+        prediction_set_id = "pred-set-456"
+        filter_dict = {"score": {"min": 0.8}}
+        
+        mock_response = {
+            "evaluationValueList": {
+                "totalCount": 150,
+                "next": "cursor-abc",
+                "data": [{"dataId": "data-1"}]
+            }
+        }
+        self.data_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.data_service.get_total_data_id_count_in_evaluation_value(
+            dataset_id=dataset_id,
+            prediction_set_id=prediction_set_id,
+            filter=filter_dict
+        )
+
+        # Assert
+        assert result == 150
+        self.data_service.request_gql.assert_called_once_with(
+            Queries.GET_EVALUATION_VALUE_LIST,
+            Queries.GET_EVALUATION_VALUE_LIST["variables"](
+                dataset_id=dataset_id,
+                prediction_set_id=prediction_set_id,
+                filter=filter_dict,
+                length=1,
+                cursor=None
+            )
+        )
+
+    def test_get_total_data_id_count_in_evaluation_value_zero_count(self):
+        """Test total count retrieval with zero results."""
+        # Arrange
+        dataset_id = "dataset-123"
+        prediction_set_id = "pred-set-456"
+        
+        mock_response = {
+            "evaluationValueList": {
+                "totalCount": 0,
+                "next": None,
+                "data": []
+            }
+        }
+        self.data_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.data_service.get_total_data_id_count_in_evaluation_value(
+            dataset_id=dataset_id,
+            prediction_set_id=prediction_set_id
+        )
+
+        # Assert
+        assert result == 0
+
+    def test_get_total_data_id_count_in_evaluation_value_missing_response(self):
+        """Test total count retrieval with missing response fields."""
+        # Arrange
+        dataset_id = "dataset-123"
+        prediction_set_id = "pred-set-456"
+        
+        mock_response = {}
+        self.data_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.data_service.get_total_data_id_count_in_evaluation_value(
+            dataset_id=dataset_id,
+            prediction_set_id=prediction_set_id
+        )
+
+        # Assert
+        assert result == 0

--- a/tests/datasets/__init__.py
+++ b/tests/datasets/__init__.py
@@ -1,0 +1,1 @@
+# Datasets test package

--- a/tests/datasets/test_dataset_service.py
+++ b/tests/datasets/test_dataset_service.py
@@ -1,0 +1,135 @@
+import pytest
+from unittest.mock import Mock
+
+from spb_onprem.datasets.service import DatasetService
+from spb_onprem.datasets.queries import Queries
+from spb_onprem.exceptions import BadParameterError
+
+
+class TestDatasetService:
+    """Test cases for DatasetService delete_dataset method."""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method."""
+        self.dataset_service = DatasetService()
+        self.dataset_service.request_gql = Mock()
+
+    def test_delete_dataset_success(self):
+        """Test successful dataset deletion."""
+        # Arrange
+        dataset_id = "dataset-123"
+        mock_response = {"deleteDataset": True}
+        self.dataset_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.dataset_service.delete_dataset(dataset_id)
+
+        # Assert
+        assert result is True
+        self.dataset_service.request_gql.assert_called_once_with(
+            Queries.DELETE_DATASET,
+            Queries.DELETE_DATASET["variables"](dataset_id=dataset_id)
+        )
+
+    def test_delete_dataset_failure(self):
+        """Test dataset deletion failure."""
+        # Arrange
+        dataset_id = "nonexistent-dataset"
+        mock_response = {"deleteDataset": False}
+        self.dataset_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.dataset_service.delete_dataset(dataset_id)
+
+        # Assert
+        assert result is False
+        self.dataset_service.request_gql.assert_called_once_with(
+            Queries.DELETE_DATASET,
+            Queries.DELETE_DATASET["variables"](dataset_id=dataset_id)
+        )
+
+    def test_delete_dataset_missing_response(self):
+        """Test dataset deletion with missing response field."""
+        # Arrange
+        dataset_id = "dataset-123"
+        mock_response = {}
+        self.dataset_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.dataset_service.delete_dataset(dataset_id)
+
+        # Assert
+        assert result is False
+
+    def test_delete_dataset_missing_dataset_id(self):
+        """Test delete dataset with missing dataset_id."""
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="dataset_id is required"):
+            self.dataset_service.delete_dataset(dataset_id=None)
+
+    def test_delete_dataset_empty_string_id(self):
+        """Test delete dataset with empty string ID."""
+        # Arrange
+        dataset_id = ""
+
+        # Act & Assert
+        # Empty string should be allowed by the service, but would fail at GraphQL level
+        mock_response = {"deleteDataset": False}
+        self.dataset_service.request_gql.return_value = mock_response
+
+        result = self.dataset_service.delete_dataset(dataset_id)
+        assert result is False
+
+    def test_delete_dataset_query_structure(self):
+        """Test that delete dataset uses correct query structure."""
+        # Arrange
+        dataset_id = "test-dataset"
+        mock_response = {"deleteDataset": True}
+        self.dataset_service.request_gql.return_value = mock_response
+
+        # Act
+        self.dataset_service.delete_dataset(dataset_id)
+
+        # Assert - Verify the query structure
+        call_args = self.dataset_service.request_gql.call_args
+        query = call_args[0][0]  # First positional argument
+        variables = call_args[0][1]  # Second positional argument
+
+        # Check query contains expected mutation
+        assert query["name"] == "deleteDataset"
+        assert "mutation DeleteDataset" in query["query"]
+        assert "deleteDataset(datasetId: $dataset_id)" in query["query"]
+
+        # Check variables function is called correctly
+        expected_variables = {"dataset_id": dataset_id}
+        assert variables == expected_variables
+
+    def test_delete_dataset_variables_function(self):
+        """Test that variables function works correctly."""
+        # Arrange
+        dataset_id = "test-variables-dataset"
+
+        # Act - Call the variables function directly
+        variables = Queries.DELETE_DATASET["variables"](dataset_id)
+
+        # Assert
+        expected_variables = {"dataset_id": dataset_id}
+        assert variables == expected_variables
+
+    def test_delete_dataset_with_special_characters(self):
+        """Test dataset deletion with special characters in ID."""
+        # Arrange
+        dataset_id = "dataset-with-special-chars_123@test"
+        mock_response = {"deleteDataset": True}
+        self.dataset_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.dataset_service.delete_dataset(dataset_id)
+
+        # Assert
+        assert result is True
+        
+        # Verify the special characters are passed through correctly
+        call_args = self.dataset_service.request_gql.call_args
+        variables = call_args[0][1]
+        assert variables["dataset_id"] == dataset_id

--- a/tests/exports/test_service.py
+++ b/tests/exports/test_service.py
@@ -378,6 +378,7 @@ class TestExportService:
             dataset_id="test_dataset_id",
             name=Undefined,
             data_filter=Undefined,
+            location=Undefined,
             data_count=Undefined,
             frame_count=Undefined,
             annotation_count=Undefined,

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,0 +1,1 @@
+# Models test package

--- a/tests/models/test_model_service.py
+++ b/tests/models/test_model_service.py
@@ -23,14 +23,12 @@ class TestModelService:
         length = 25
         
         mock_response = {
-            "models": {
-                "models": [
-                    {"id": "model-1", "name": "Model 1"},
-                    {"id": "model-2", "name": "Model 2"}
-                ],
-                "next": "cursor-def",
-                "totalCount": 50
-            }
+            "models": [
+                {"id": "model-1", "name": "Model 1"},
+                {"id": "model-2", "name": "Model 2"}
+            ],
+            "next": "cursor-def",
+            "totalCount": 50
         }
         self.model_service.request_gql.return_value = mock_response
 
@@ -43,15 +41,14 @@ class TestModelService:
         )
 
         # Assert
-        expected_result = {
-            "models": [
-                {"id": "model-1", "name": "Model 1"},
-                {"id": "model-2", "name": "Model 2"}
-            ],
-            "next": "cursor-def",
-            "totalCount": 50
-        }
-        assert result == expected_result
+        models, next_cursor, total_count = result
+        assert len(models) == 2
+        assert models[0].id == "model-1"
+        assert models[0].name == "Model 1"
+        assert models[1].id == "model-2"
+        assert models[1].name == "Model 2"
+        assert next_cursor == "cursor-def"
+        assert total_count == 50
         self.model_service.request_gql.assert_called_once_with(
             Queries.GET_MODELS,
             Queries.GET_MODELS["variables"](
@@ -68,11 +65,9 @@ class TestModelService:
         dataset_id = "dataset-123"
         
         mock_response = {
-            "models": {
-                "models": [{"id": "model-1", "name": "Test Model"}],
-                "next": None,
-                "totalCount": 1
-            }
+            "models": [{"id": "model-1", "name": "Test Model"}],
+            "next": None,
+            "totalCount": 1
         }
         self.model_service.request_gql.return_value = mock_response
 
@@ -80,10 +75,11 @@ class TestModelService:
         result = self.model_service.get_models(dataset_id=dataset_id)
 
         # Assert
-        assert result["totalCount"] == 1
-        assert result["next"] is None
-        assert len(result["models"]) == 1
-        assert result["models"][0]["name"] == "Test Model"
+        models, next_cursor, total_count = result
+        assert total_count == 1
+        assert next_cursor is None
+        assert len(models) == 1
+        assert models[0].name == "Test Model"
 
     def test_get_models_with_pagination(self):
         """Test models retrieval with pagination parameters."""
@@ -93,14 +89,12 @@ class TestModelService:
         length = 10
         
         mock_response = {
-            "models": {
-                "models": [
-                    {"id": "model-3", "name": "Model 3"},
-                    {"id": "model-4", "name": "Model 4"}
-                ],
-                "next": "next-cursor",
-                "totalCount": 20
-            }
+            "models": [
+                {"id": "model-3", "name": "Model 3"},
+                {"id": "model-4", "name": "Model 4"}
+            ],
+            "next": "next-cursor",
+            "totalCount": 20
         }
         self.model_service.request_gql.return_value = mock_response
 
@@ -112,9 +106,10 @@ class TestModelService:
         )
 
         # Assert
-        assert result["next"] == "next-cursor"
-        assert result["totalCount"] == 20
-        assert len(result["models"]) == 2
+        models, next_cursor, total_count = result
+        assert next_cursor == "next-cursor"
+        assert total_count == 20
+        assert len(models) == 2
 
     def test_get_models_missing_dataset_id(self):
         """Test models with missing dataset_id."""
@@ -133,7 +128,10 @@ class TestModelService:
         result = self.model_service.get_models(dataset_id=dataset_id)
 
         # Assert
-        assert result == {}
+        models, next_cursor, total_count = result
+        assert len(models) == 0
+        assert next_cursor is None
+        assert total_count == 0
 
     def test_get_models_zero_results(self):
         """Test models retrieval with zero results."""
@@ -141,11 +139,9 @@ class TestModelService:
         dataset_id = "empty-dataset"
         
         mock_response = {
-            "models": {
-                "models": [],
-                "next": None,
-                "totalCount": 0
-            }
+            "models": [],
+            "next": None,
+            "totalCount": 0
         }
         self.model_service.request_gql.return_value = mock_response
 
@@ -153,9 +149,10 @@ class TestModelService:
         result = self.model_service.get_models(dataset_id=dataset_id)
 
         # Assert
-        assert result["totalCount"] == 0
-        assert result["next"] is None
-        assert len(result["models"]) == 0
+        models, next_cursor, total_count = result
+        assert total_count == 0
+        assert next_cursor is None
+        assert len(models) == 0
 
     def test_delete_model_success(self):
         """Test successful model deletion."""

--- a/tests/models/test_model_service.py
+++ b/tests/models/test_model_service.py
@@ -1,0 +1,252 @@
+import pytest
+from unittest.mock import Mock
+
+from spb_onprem.models.service import ModelService
+from spb_onprem.models.queries import Queries
+from spb_onprem.exceptions import BadParameterError
+
+
+class TestModelService:
+    """Test cases for ModelService methods."""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method."""
+        self.model_service = ModelService()
+        self.model_service.request_gql = Mock()
+
+    def test_get_models_success(self):
+        """Test successful models list retrieval."""
+        # Arrange
+        dataset_id = "dataset-123"
+        filter_dict = {"name": "test"}
+        cursor = "cursor-abc"
+        length = 25
+        
+        mock_response = {
+            "models": {
+                "models": [
+                    {"id": "model-1", "name": "Model 1"},
+                    {"id": "model-2", "name": "Model 2"}
+                ],
+                "next": "cursor-def",
+                "totalCount": 50
+            }
+        }
+        self.model_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.model_service.get_models(
+            dataset_id=dataset_id,
+            filter=filter_dict,
+            cursor=cursor,
+            length=length
+        )
+
+        # Assert
+        expected_result = {
+            "models": [
+                {"id": "model-1", "name": "Model 1"},
+                {"id": "model-2", "name": "Model 2"}
+            ],
+            "next": "cursor-def",
+            "totalCount": 50
+        }
+        assert result == expected_result
+        self.model_service.request_gql.assert_called_once_with(
+            Queries.GET_MODELS,
+            Queries.GET_MODELS["variables"](
+                dataset_id=dataset_id,
+                filter=filter_dict,
+                cursor=cursor,
+                length=length
+            )
+        )
+
+    def test_get_models_without_filter(self):
+        """Test models retrieval without filter."""
+        # Arrange
+        dataset_id = "dataset-123"
+        
+        mock_response = {
+            "models": {
+                "models": [{"id": "model-1", "name": "Test Model"}],
+                "next": None,
+                "totalCount": 1
+            }
+        }
+        self.model_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.model_service.get_models(dataset_id=dataset_id)
+
+        # Assert
+        assert result["totalCount"] == 1
+        assert result["next"] is None
+        assert len(result["models"]) == 1
+        assert result["models"][0]["name"] == "Test Model"
+
+    def test_get_models_with_pagination(self):
+        """Test models retrieval with pagination parameters."""
+        # Arrange
+        dataset_id = "dataset-123"
+        cursor = "pagination-cursor"
+        length = 10
+        
+        mock_response = {
+            "models": {
+                "models": [
+                    {"id": "model-3", "name": "Model 3"},
+                    {"id": "model-4", "name": "Model 4"}
+                ],
+                "next": "next-cursor",
+                "totalCount": 20
+            }
+        }
+        self.model_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.model_service.get_models(
+            dataset_id=dataset_id,
+            cursor=cursor,
+            length=length
+        )
+
+        # Assert
+        assert result["next"] == "next-cursor"
+        assert result["totalCount"] == 20
+        assert len(result["models"]) == 2
+
+    def test_get_models_missing_dataset_id(self):
+        """Test models with missing dataset_id."""
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="dataset_id is required"):
+            self.model_service.get_models(dataset_id=None)
+
+    def test_get_models_empty_response(self):
+        """Test models with empty response."""
+        # Arrange
+        dataset_id = "dataset-123"
+        mock_response = {}
+        self.model_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.model_service.get_models(dataset_id=dataset_id)
+
+        # Assert
+        assert result == {}
+
+    def test_get_models_zero_results(self):
+        """Test models retrieval with zero results."""
+        # Arrange
+        dataset_id = "empty-dataset"
+        
+        mock_response = {
+            "models": {
+                "models": [],
+                "next": None,
+                "totalCount": 0
+            }
+        }
+        self.model_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.model_service.get_models(dataset_id=dataset_id)
+
+        # Assert
+        assert result["totalCount"] == 0
+        assert result["next"] is None
+        assert len(result["models"]) == 0
+
+    def test_delete_model_success(self):
+        """Test successful model deletion."""
+        # Arrange
+        dataset_id = "dataset-123"
+        model_id = "model-456"
+        
+        mock_response = {"deleteModel": True}
+        self.model_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.model_service.delete_model(
+            dataset_id=dataset_id,
+            model_id=model_id
+        )
+
+        # Assert
+        assert result is True
+        self.model_service.request_gql.assert_called_once_with(
+            Queries.DELETE_MODEL,
+            Queries.DELETE_MODEL["variables"](
+                dataset_id=dataset_id,
+                model_id=model_id
+            )
+        )
+
+    def test_delete_model_failure(self):
+        """Test model deletion failure."""
+        # Arrange
+        dataset_id = "dataset-123"
+        model_id = "nonexistent-model"
+        
+        mock_response = {"deleteModel": False}
+        self.model_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.model_service.delete_model(
+            dataset_id=dataset_id,
+            model_id=model_id
+        )
+
+        # Assert
+        assert result is False
+
+    def test_delete_model_missing_response(self):
+        """Test model deletion with missing response field."""
+        # Arrange
+        dataset_id = "dataset-123"
+        model_id = "model-456"
+        
+        mock_response = {}
+        self.model_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.model_service.delete_model(
+            dataset_id=dataset_id,
+            model_id=model_id
+        )
+
+        # Assert
+        assert result is False
+
+    def test_delete_model_missing_dataset_id(self):
+        """Test delete model with missing dataset_id."""
+        # Arrange
+        model_id = "model-456"
+
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="dataset_id is required"):
+            self.model_service.delete_model(
+                dataset_id=None,
+                model_id=model_id
+            )
+
+    def test_delete_model_missing_model_id(self):
+        """Test delete model with missing model_id."""
+        # Arrange
+        dataset_id = "dataset-123"
+
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="model_id is required"):
+            self.model_service.delete_model(
+                dataset_id=dataset_id,
+                model_id=None
+            )
+
+    def test_delete_model_both_missing_params(self):
+        """Test delete model with both missing parameters."""
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="dataset_id is required"):
+            self.model_service.delete_model(
+                dataset_id=None,
+                model_id=None
+            )

--- a/tests/predictions/__init__.py
+++ b/tests/predictions/__init__.py
@@ -1,0 +1,1 @@
+# Predictions test package

--- a/tests/predictions/test_prediction_service.py
+++ b/tests/predictions/test_prediction_service.py
@@ -276,7 +276,7 @@ class TestPredictionService:
         data_id = "data-456"
         prediction_set_id = "pred-set-789"
         
-        mock_response = {"removePredictionFromData": True}
+        mock_response = {"deletePrediction": {"id": data_id, "dataset_id": dataset_id}}
         self.prediction_service.request_gql.return_value = mock_response
 
         # Act
@@ -304,7 +304,7 @@ class TestPredictionService:
         data_id = "data-456"
         prediction_set_id = "pred-set-789"
         
-        mock_response = {"removePredictionFromData": False}
+        mock_response = {"deletePrediction": None}
         self.prediction_service.request_gql.return_value = mock_response
 
         # Act

--- a/tests/predictions/test_prediction_service.py
+++ b/tests/predictions/test_prediction_service.py
@@ -1,0 +1,360 @@
+import pytest
+from unittest.mock import Mock
+
+from spb_onprem.predictions.service import PredictionService
+from spb_onprem.predictions.queries import Queries
+from spb_onprem.predictions.entities import PredictionSet
+from spb_onprem.exceptions import BadParameterError
+
+
+class TestPredictionService:
+    """Test cases for PredictionService methods."""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method."""
+        self.prediction_service = PredictionService()
+        self.prediction_service.request_gql = Mock()
+
+    def test_get_prediction_sets_success(self):
+        """Test successful prediction sets list retrieval."""
+        # Arrange
+        dataset_id = "dataset-123"
+        filter_dict = {"name": "test"}
+        cursor = "cursor-abc"
+        length = 25
+        
+        mock_response = {
+            "predictionSets": {
+                "predictionSets": [
+                    {"id": "pred-1", "name": "Prediction Set 1"},
+                    {"id": "pred-2", "name": "Prediction Set 2"}
+                ],
+                "next": "cursor-def",
+                "totalCount": 100
+            }
+        }
+        self.prediction_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.prediction_service.get_prediction_sets(
+            dataset_id=dataset_id,
+            filter=filter_dict,
+            cursor=cursor,
+            length=length
+        )
+
+        # Assert
+        expected_result = {
+            "predictionSets": [
+                {"id": "pred-1", "name": "Prediction Set 1"},
+                {"id": "pred-2", "name": "Prediction Set 2"}
+            ],
+            "next": "cursor-def",
+            "totalCount": 100
+        }
+        assert result == expected_result
+        self.prediction_service.request_gql.assert_called_once_with(
+            Queries.GET_PREDICTION_SETS,
+            Queries.GET_PREDICTION_SETS["variables"](
+                dataset_id=dataset_id,
+                filter=filter_dict,
+                cursor=cursor,
+                length=length
+            )
+        )
+
+    def test_get_prediction_sets_without_filter(self):
+        """Test prediction sets retrieval without filter."""
+        # Arrange
+        dataset_id = "dataset-123"
+        
+        mock_response = {
+            "predictionSets": {
+                "predictionSets": [{"id": "pred-1", "name": "Test"}],
+                "next": None,
+                "totalCount": 1
+            }
+        }
+        self.prediction_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.prediction_service.get_prediction_sets(dataset_id=dataset_id)
+
+        # Assert
+        assert result["totalCount"] == 1
+        assert result["next"] is None
+        assert len(result["predictionSets"]) == 1
+
+    def test_get_prediction_sets_missing_dataset_id(self):
+        """Test prediction sets with missing dataset_id."""
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="dataset_id is required"):
+            self.prediction_service.get_prediction_sets(dataset_id=None)
+
+    def test_get_prediction_sets_empty_response(self):
+        """Test prediction sets with empty response."""
+        # Arrange
+        dataset_id = "dataset-123"
+        mock_response = {}
+        self.prediction_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.prediction_service.get_prediction_sets(dataset_id=dataset_id)
+
+        # Assert
+        assert result == {}
+
+    def test_get_prediction_set_success(self):
+        """Test successful single prediction set retrieval."""
+        # Arrange
+        dataset_id = "dataset-123"
+        prediction_set_id = "pred-set-456"
+        
+        mock_response = {
+            "predictionSet": {
+                "id": prediction_set_id,
+                "name": "Test Prediction Set",
+                "annotationsContents": ["content-1", "content-2"],
+                "evaluationResultContent": {"id": "eval-result-1"}
+            }
+        }
+        self.prediction_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.prediction_service.get_prediction_set(
+            dataset_id=dataset_id,
+            prediction_set_id=prediction_set_id
+        )
+
+        # Assert
+        assert isinstance(result, PredictionSet)
+        assert result.id == prediction_set_id
+        assert result.name == "Test Prediction Set"
+        assert result.annotations_contents == ["content-1", "content-2"]
+        assert result.evaluation_result_content == {"id": "eval-result-1"}
+        self.prediction_service.request_gql.assert_called_once_with(
+            Queries.GET_PREDICTION_SET,
+            Queries.GET_PREDICTION_SET["variables"](
+                dataset_id=dataset_id,
+                prediction_set_id=prediction_set_id
+            )
+        )
+
+    def test_get_prediction_set_missing_dataset_id(self):
+        """Test get prediction set with missing dataset_id."""
+        # Arrange
+        prediction_set_id = "pred-set-456"
+
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="dataset_id is required"):
+            self.prediction_service.get_prediction_set(
+                dataset_id=None,
+                prediction_set_id=prediction_set_id
+            )
+
+    def test_get_prediction_set_missing_prediction_set_id(self):
+        """Test get prediction set with missing prediction_set_id."""
+        # Arrange
+        dataset_id = "dataset-123"
+
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="prediction_set_id is required"):
+            self.prediction_service.get_prediction_set(
+                dataset_id=dataset_id,
+                prediction_set_id=None
+            )
+
+    def test_get_prediction_set_minimal_response(self):
+        """Test get prediction set with minimal response."""
+        # Arrange
+        dataset_id = "dataset-123"
+        prediction_set_id = "pred-set-456"
+        
+        mock_response = {"predictionSet": {"id": prediction_set_id}}
+        self.prediction_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.prediction_service.get_prediction_set(
+            dataset_id=dataset_id,
+            prediction_set_id=prediction_set_id
+        )
+
+        # Assert
+        assert isinstance(result, PredictionSet)
+        assert result.id == prediction_set_id
+        assert result.name is None  # Optional fields should be None
+
+    def test_delete_prediction_set_success(self):
+        """Test successful prediction set deletion."""
+        # Arrange
+        dataset_id = "dataset-123"
+        prediction_set_id = "pred-set-456"
+        
+        mock_response = {"deletePredictionSet": True}
+        self.prediction_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.prediction_service.delete_prediction_set(
+            dataset_id=dataset_id,
+            prediction_set_id=prediction_set_id
+        )
+
+        # Assert
+        assert result is True
+        self.prediction_service.request_gql.assert_called_once_with(
+            Queries.DELETE_PREDICTION_SET,
+            Queries.DELETE_PREDICTION_SET["variables"](
+                dataset_id=dataset_id,
+                prediction_set_id=prediction_set_id
+            )
+        )
+
+    def test_delete_prediction_set_failure(self):
+        """Test prediction set deletion failure."""
+        # Arrange
+        dataset_id = "dataset-123"
+        prediction_set_id = "nonexistent-pred-set"
+        
+        mock_response = {"deletePredictionSet": False}
+        self.prediction_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.prediction_service.delete_prediction_set(
+            dataset_id=dataset_id,
+            prediction_set_id=prediction_set_id
+        )
+
+        # Assert
+        assert result is False
+
+    def test_delete_prediction_set_missing_response(self):
+        """Test prediction set deletion with missing response field."""
+        # Arrange
+        dataset_id = "dataset-123"
+        prediction_set_id = "pred-set-456"
+        
+        mock_response = {}
+        self.prediction_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.prediction_service.delete_prediction_set(
+            dataset_id=dataset_id,
+            prediction_set_id=prediction_set_id
+        )
+
+        # Assert
+        assert result is False
+
+    def test_delete_prediction_set_missing_dataset_id(self):
+        """Test delete prediction set with missing dataset_id."""
+        # Arrange
+        prediction_set_id = "pred-set-456"
+
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="dataset_id is required"):
+            self.prediction_service.delete_prediction_set(
+                dataset_id=None,
+                prediction_set_id=prediction_set_id
+            )
+
+    def test_delete_prediction_set_missing_prediction_set_id(self):
+        """Test delete prediction set with missing prediction_set_id."""
+        # Arrange
+        dataset_id = "dataset-123"
+
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="prediction_set_id is required"):
+            self.prediction_service.delete_prediction_set(
+                dataset_id=dataset_id,
+                prediction_set_id=None
+            )
+
+    def test_delete_prediction_from_data_success(self):
+        """Test successful prediction deletion from data."""
+        # Arrange
+        dataset_id = "dataset-123"
+        data_id = "data-456"
+        prediction_set_id = "pred-set-789"
+        
+        mock_response = {"removePredictionFromData": True}
+        self.prediction_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.prediction_service.delete_prediction_from_data(
+            dataset_id=dataset_id,
+            data_id=data_id,
+            prediction_set_id=prediction_set_id
+        )
+
+        # Assert
+        assert result is True
+        self.prediction_service.request_gql.assert_called_once_with(
+            Queries.DELETE_PREDICTION_FROM_DATA,
+            Queries.DELETE_PREDICTION_FROM_DATA["variables"](
+                dataset_id=dataset_id,
+                data_id=data_id,
+                prediction_set_id=prediction_set_id
+            )
+        )
+
+    def test_delete_prediction_from_data_failure(self):
+        """Test prediction deletion from data failure."""
+        # Arrange
+        dataset_id = "dataset-123"
+        data_id = "data-456"
+        prediction_set_id = "pred-set-789"
+        
+        mock_response = {"removePredictionFromData": False}
+        self.prediction_service.request_gql.return_value = mock_response
+
+        # Act
+        result = self.prediction_service.delete_prediction_from_data(
+            dataset_id=dataset_id,
+            data_id=data_id,
+            prediction_set_id=prediction_set_id
+        )
+
+        # Assert
+        assert result is False
+
+    def test_delete_prediction_from_data_missing_dataset_id(self):
+        """Test delete prediction from data with missing dataset_id."""
+        # Arrange
+        data_id = "data-456"
+        prediction_set_id = "pred-set-789"
+
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="dataset_id is required"):
+            self.prediction_service.delete_prediction_from_data(
+                dataset_id=None,
+                data_id=data_id,
+                prediction_set_id=prediction_set_id
+            )
+
+    def test_delete_prediction_from_data_missing_data_id(self):
+        """Test delete prediction from data with missing data_id."""
+        # Arrange
+        dataset_id = "dataset-123"
+        prediction_set_id = "pred-set-789"
+
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="data_id is required"):
+            self.prediction_service.delete_prediction_from_data(
+                dataset_id=dataset_id,
+                data_id=None,
+                prediction_set_id=prediction_set_id
+            )
+
+    def test_delete_prediction_from_data_missing_prediction_set_id(self):
+        """Test delete prediction from data with missing prediction_set_id."""
+        # Arrange
+        dataset_id = "dataset-123"
+        data_id = "data-456"
+
+        # Act & Assert
+        with pytest.raises(BadParameterError, match="prediction_set_id is required"):
+            self.prediction_service.delete_prediction_from_data(
+                dataset_id=dataset_id,
+                data_id=data_id,
+                prediction_set_id=None
+            )

--- a/tests/predictions/test_prediction_service.py
+++ b/tests/predictions/test_prediction_service.py
@@ -24,14 +24,12 @@ class TestPredictionService:
         length = 25
         
         mock_response = {
-            "predictionSets": {
-                "predictionSets": [
-                    {"id": "pred-1", "name": "Prediction Set 1"},
-                    {"id": "pred-2", "name": "Prediction Set 2"}
-                ],
-                "next": "cursor-def",
-                "totalCount": 100
-            }
+            "predictionSets": [
+                {"id": "pred-1", "name": "Prediction Set 1"},
+                {"id": "pred-2", "name": "Prediction Set 2"}
+            ],
+            "next": "cursor-def",
+            "totalCount": 100
         }
         self.prediction_service.request_gql.return_value = mock_response
 
@@ -44,15 +42,14 @@ class TestPredictionService:
         )
 
         # Assert
-        expected_result = {
-            "predictionSets": [
-                {"id": "pred-1", "name": "Prediction Set 1"},
-                {"id": "pred-2", "name": "Prediction Set 2"}
-            ],
-            "next": "cursor-def",
-            "totalCount": 100
-        }
-        assert result == expected_result
+        prediction_sets, next_cursor, total_count = result
+        assert len(prediction_sets) == 2
+        assert prediction_sets[0].id == "pred-1"
+        assert prediction_sets[0].name == "Prediction Set 1"
+        assert prediction_sets[1].id == "pred-2"
+        assert prediction_sets[1].name == "Prediction Set 2"
+        assert next_cursor == "cursor-def"
+        assert total_count == 100
         self.prediction_service.request_gql.assert_called_once_with(
             Queries.GET_PREDICTION_SETS,
             Queries.GET_PREDICTION_SETS["variables"](
@@ -69,11 +66,9 @@ class TestPredictionService:
         dataset_id = "dataset-123"
         
         mock_response = {
-            "predictionSets": {
-                "predictionSets": [{"id": "pred-1", "name": "Test"}],
-                "next": None,
-                "totalCount": 1
-            }
+            "predictionSets": [{"id": "pred-1", "name": "Test"}],
+            "next": None,
+            "totalCount": 1
         }
         self.prediction_service.request_gql.return_value = mock_response
 
@@ -81,9 +76,10 @@ class TestPredictionService:
         result = self.prediction_service.get_prediction_sets(dataset_id=dataset_id)
 
         # Assert
-        assert result["totalCount"] == 1
-        assert result["next"] is None
-        assert len(result["predictionSets"]) == 1
+        prediction_sets, next_cursor, total_count = result
+        assert total_count == 1
+        assert next_cursor is None
+        assert len(prediction_sets) == 1
 
     def test_get_prediction_sets_missing_dataset_id(self):
         """Test prediction sets with missing dataset_id."""
@@ -102,7 +98,10 @@ class TestPredictionService:
         result = self.prediction_service.get_prediction_sets(dataset_id=dataset_id)
 
         # Assert
-        assert result == {}
+        prediction_sets, next_cursor, total_count = result
+        assert len(prediction_sets) == 0
+        assert next_cursor is None
+        assert total_count == 0
 
     def test_get_prediction_set_success(self):
         """Test successful single prediction set retrieval."""


### PR DESCRIPTION
1. 새로운 SDK 서비스 모듈 추가

  Models 서비스 (신규 추가)

  - spb_onprem/models/service.py (70라인)
  - spb_onprem/models/queries.py (33라인)
  - spb_onprem/models/entities.py (9라인)
  - 기능: 모델 조회 및 삭제 기능

  Predictions 서비스 (신규 추가)

  - spb_onprem/predictions/service.py (132라인)
  - spb_onprem/predictions/queries.py (62라인)
  - spb_onprem/predictions/entities.py (19라인)
  - 기능: 예측 세트 관리 및 예측 데이터 삭제

  Data 서비스 확장

  - spb_onprem/data/service.py 확장 (95라인 총)
  - spb_onprem/data/queries.py 확장 (70라인 총)
  - 신규 기능:
    - get_data_detail() - 데이터 상세 조회
    - get_evaluation_value_list() - 평가 값 목록 조회

  Contents 서비스 (신규 추가)

  - spb_onprem/contents/service.py (19라인)
  - 기능: 콘텐츠 삭제 기능

  Datasets 서비스 확장

  - spb_onprem/datasets/service.py 확장 (18라인)
  - 신규 기능: delete_dataset() 메서드

  2. 파라미터 변환 모듈

  각 서비스별로 GraphQL 파라미터 변환 함수들 추가:
  - models/params/: delete_model.py, get_models.py
  - predictions/params/: delete_prediction_from_data.py,
  delete_prediction_set.py, get_prediction_sets.py
  - data/params/: get_data_detail.py, get_evaluation_value_list.py

  3. 포괄적인 테스트 코드 (1,259라인)

  단위 테스트 파일들:

  - tests/models/test_model_service.py (252라인)
  - tests/predictions/test_prediction_service.py (360라인)
  - tests/data/test_data_service.py (413라인)
  - tests/datasets/test_dataset_service.py (135라인)
  - tests/contents/test_content_service.py (99라인)

  4. 핵심 커밋 분석

  메인 커밋: b6b3510 - feat: Add comprehensive SDK services and evaluation 
  methods

  - Models, Predictions, Data 서비스의 핵심 기능들 구현
  - GraphQL 쿼리 및 파라미터 변환 로직 추가
  - Pydantic 기반 엔티티 모델 정의

  후속 개선: b70e41c - feat: make get data detail delete, content api

  - Data 서비스에 상세 조회 기능 추가
  - Contents 서비스 삭제 기능 구현

  5. 아키텍처 특징

  ★ Insight ─────────────────────────────────────
  이 SDK는 일관된 아키텍처 패턴을 따릅니다:
  1. service.py: 비즈니스 로직과 API 호출
  2. queries.py: GraphQL 쿼리/뮤테이션 정의
  3. params/: 파라미터 변환 및 검증
  4. entities.py: Pydantic 모델 정의
  5. 포괄적인 단위 테스트: 각 서비스당 평균 200+ 라인의 테스트
  ─────────────────────────────────────────────────

  6. 새로운 SDK 기능들

  Models:

  - get_models(): 모델 목록 조회 (페이지네이션 지원)
  - delete_model(): 모델 삭제

  Predictions:

  - get_prediction_sets(): 예측 세트 목록 조회
  - get_prediction_set(): 단일 예측 세트 조회
  - delete_prediction_set(): 예측 세트 삭제
  - delete_prediction_from_data(): 데이터에서 예측 제거

  Data (확장):

  - get_data_detail(): 데이터 상세 정보 조회
  - get_evaluation_value_list(): 평가 값 목록 조회 (커서 기반 페이지네이션)

  7. 테스트 커버리지

  각 서비스별로 다음 시나리오들을 테스트:
  - 성공 케이스 (정상 응답)
  - 실패 케이스 (잘못된 파라미터, API 오류)
  - 엣지 케이스 (빈 결과, None 값)
  - 파라미터 검증 (필수 파라미터 누락)