### PR TITLE
fix: correct GraphQL variable mapping in delete_data params

### DIFF
--- a/spb_onprem/data/params/delete_data.py
+++ b/spb_onprem/data/params/delete_data.py
@@ -13,5 +13,5 @@ def delete_data_params(
     
     return {
         "dataset_id": dataset_id,
-        "id": data_id,
+        "data_id": data_id,
     }


### PR DESCRIPTION
- Change 'id' to 'data_id' in delete_data_params return value
- Ensures GraphQL variable  is properly provided at runtime
- Fixes 'variable was not provided a runtime value' error