### PR TITLE
fix: correct delete_data response handling for Boolean return

### DIFF
--- a/spb_onprem/data/service.py
+++ b/spb_onprem/data/service.py
@@ -291,7 +291,7 @@ class DataService(BaseService):
             Queries.DELETE,
             Queries.DELETE["variables"](dataset_id=dataset_id, data_id=data_id)
         )
-        return response.get("deleteData", False)
+        return response
 
     def insert_prediction(
         self,


### PR DESCRIPTION
- Remove .get() call on Boolean response from request_gql
- DELETE mutation returns Boolean directly, not dictionary
- Fixes AttributeError: 'bool' object has no attribute 'get'