### PR TITLE
feat(data): add sliceIdAll filter and workflow validation

### DIFF
--- a/spb_onprem/data/params/data_list.py
+++ b/spb_onprem/data/params/data_list.py
@@ -210,6 +210,7 @@ class DataFilterOptions(CustomBaseModel):
     # ID 및 키 필터
     id_in: Optional[List[str]] = Field(None, alias="idIn", description="특정 데이터 ID 목록 중 하나")
     slice_id_in: Optional[List[str]] = Field(None, alias="sliceIdIn", description="특정 슬라이스 ID 목록에 속한 데이터")
+    slice_id_all: Optional[List[str]] = Field(None, alias="sliceIdAll", description="모든 슬라이스 ID 목록에 속한 데이터")
     
     # 키 패턴 필터
     key_contains: Optional[str] = Field(None, alias="keyContains", description="키에 포함된 문자열")


### PR DESCRIPTION
## Summary
Add support for data filter field `sliceIdAll` and validate it in workflow test.

## Changes
- Add `slice_id_all` (alias: `sliceIdAll`) to DataFilterOptions.
- Add workflow verification step for `slice_id_all` in data workflow test.

## Testing
- pipenv run pytest -q tests/data
- Result: 6 passed, 1 skipped
