### PR TITLE
feat: add job_history_id to create_model and create_diagnosis

### DIFF
--- a/spb_onprem/diagnoses/params/create_diagnosis.py
+++ b/spb_onprem/diagnoses/params/create_diagnosis.py
@@ -20,6 +20,7 @@ def create_diagnosis_params(
     model_id: Optional[str] = None,
     discriminator_key: Optional[str] = None,
     discriminator_values: Optional[List[str]] = None,
+    job_history_id: Optional[str] = None,
 ):
     if dataset_id is None:
         raise BadParameterError("dataset_id is required.")
@@ -43,4 +44,5 @@ def create_diagnosis_params(
         "model_id": model_id,
         "discriminator_key": discriminator_key,
         "discriminator_values": discriminator_values,
+        "job_history_id": job_history_id,
     }

--- a/spb_onprem/diagnoses/queries.py
+++ b/spb_onprem/diagnoses/queries.py
@@ -47,6 +47,7 @@ class Schemas:
         modelId
         discriminatorKey
         discriminatorValues
+        jobHistoryId
         completedAt
         createdAt
         updatedAt
@@ -124,6 +125,7 @@ class Queries:
                 $model_id: ID,
                 $discriminator_key: String,
                 $discriminator_values: [String!],
+                $job_history_id: ID,
             ) {{
                 createDiagnosis(
                     datasetId: $dataset_id,
@@ -142,6 +144,7 @@ class Queries:
                     modelId: $model_id,
                     discriminatorKey: $discriminator_key,
                     discriminatorValues: $discriminator_values,
+                    jobHistoryId: $job_history_id,
                 ) {{
                     {Schemas.DIAGNOSIS}
                 }}

--- a/spb_onprem/diagnoses/service.py
+++ b/spb_onprem/diagnoses/service.py
@@ -136,6 +136,7 @@ class DiagnosisService(BaseService):
         model_id: Optional[str] = None,
         discriminator_key: Optional[str] = None,
         discriminator_values: Optional[List[str]] = None,
+        job_history_id: Optional[str] = None,
     ) -> Diagnosis:
         """diagnosis 생성.
 
@@ -179,6 +180,7 @@ class DiagnosisService(BaseService):
                 model_id=model_id,
                 discriminator_key=discriminator_key,
                 discriminator_values=discriminator_values,
+                job_history_id=job_history_id,
             ),
         )
         return Diagnosis.model_validate(response)

--- a/spb_onprem/models/params/create_model.py
+++ b/spb_onprem/models/params/create_model.py
@@ -25,6 +25,7 @@ def create_model_params(
     score_value: Optional[float] = None,
     score_unit: Optional[str] = None,
     contents: Optional[dict] = None,
+    job_history_id: Optional[str] = None,
 ):
     if dataset_id is None:
         raise BadParameterError("dataset_id is required.")
@@ -75,4 +76,5 @@ def create_model_params(
         "score_value": score_value,
         "score_unit": score_unit,
         "contents": contents,
+        "job_history_id": job_history_id,
     }

--- a/spb_onprem/models/queries.py
+++ b/spb_onprem/models/queries.py
@@ -57,6 +57,7 @@ class Schemas:
         scoreKey
         scoreValue
         scoreUnit
+        jobHistoryId
         createdAt
         updatedAt
         createdBy
@@ -134,6 +135,7 @@ class Queries:
                 $score_unit: String,
                 $contents: JSONObject,
                 $training_annotations: [TrainingAnnotationsInput!],
+                $job_history_id: ID,
             ) {{
                 createModel(
                     datasetId: $dataset_id,
@@ -153,6 +155,7 @@ class Queries:
                     scoreUnit: $score_unit,
                     contents: $contents,
                     trainingAnnotations: $training_annotations,
+                    jobHistoryId: $job_history_id,
                 ) {{
                     {Schemas.MODEL}
                 }}

--- a/spb_onprem/models/service.py
+++ b/spb_onprem/models/service.py
@@ -97,6 +97,7 @@ class ModelService(BaseService):
         score_value: Optional[float] = None,
         score_unit: Optional[str] = None,
         contents: Optional[dict] = None,
+        job_history_id: Optional[str] = None,
     ) -> Model:
         response = self.request_gql(
             Queries.CREATE,
@@ -118,6 +119,7 @@ class ModelService(BaseService):
                 score_value=score_value,
                 score_unit=score_unit,
                 contents=contents,
+                job_history_id=job_history_id,
             ),
         )
         return Model.model_validate(response)


### PR DESCRIPTION
## Summary
- `create_model`, `create_diagnosis` 에 optional `job_history_id` 파라미터 추가
- Sunrise 측 workflow engine 의 auto-resolve 로직이 Model/Diagnosis 엔티티에 저장된 `jobHistoryId` 로 workflow output 을 자동 식별할 수 있도록 지원
- Airflow DAG (cremant) 에서 entity 생성 시 `activity_history_id` 를 그대로 전달하여 서버측 자동 매핑을 가능하게 함

## Context
- Sunrise 의 Model/Diagnosis 엔티티에 `jobHistoryId` FK 가 추가됐고, workflow engine 이 이 값을 사용해 `modelId` / `diagnosisId` 를 자동 resolve 함
- 기존에 DAG 에서 수행하던 `report_workflow_output_to_sunrise` 방식 대신 SDK 레벨에서 `job_history_id` 만 넘기면 되도록 단순화
- 파라미터는 optional 이라 기존 호출에는 영향 없음

## Test plan
- [ ] 기존 `create_model` / `create_diagnosis` 호출 (job_history_id 없이) 정상 동작 확인
- [ ] `job_history_id` 전달 시 GraphQL payload 에 포함되는지 확인
- [ ] cremant PR 연동 E2E 테스트

Made with [Cursor](https://cursor.com)