### PR TITLE
fix: preserve slice data filters

### DIFF
--- a/spb_onprem/data/params/data_list.py
+++ b/spb_onprem/data/params/data_list.py
@@ -1,4 +1,5 @@
 from typing import Optional, List, Union, Literal
+from pydantic import AliasChoices
 from spb_onprem.base_model import CustomBaseModel, Field
 from spb_onprem.data.enums import DataType, DataStatus
 from spb_onprem.exceptions import BadParameterError
@@ -209,8 +210,34 @@ class DataFilterOptions(CustomBaseModel):
     """
     # ID 및 키 필터
     id_in: Optional[List[str]] = Field(None, alias="idIn", description="특정 데이터 ID 목록 중 하나")
-    slice_id_in: Optional[List[str]] = Field(None, alias="sliceIdIn", description="특정 슬라이스 ID 목록에 속한 데이터")
-    slice_id_all: Optional[List[str]] = Field(None, alias="sliceIdAll", description="모든 슬라이스 ID 목록에 속한 데이터")
+    slice_id: Optional[str] = Field(
+        None,
+        alias="sliceId",
+        validation_alias=AliasChoices("sliceId", "SliceId", "slice_id"),
+        serialization_alias="sliceId",
+        description="특정 슬라이스 ID에 속한 데이터",
+    )
+    slice_id_in: Optional[List[str]] = Field(
+        None,
+        alias="sliceIdIn",
+        validation_alias=AliasChoices("sliceIdIn", "SliceIdIn", "slice_id_in"),
+        serialization_alias="sliceIdIn",
+        description="특정 슬라이스 ID 목록에 속한 데이터",
+    )
+    slice_id_all: Optional[List[str]] = Field(
+        None,
+        alias="sliceIdAll",
+        validation_alias=AliasChoices("sliceIdAll", "SliceIdAll", "slice_id_all"),
+        serialization_alias="sliceIdAll",
+        description="모든 슬라이스 ID 목록에 속한 데이터",
+    )
+    slice_id_exists: Optional[bool] = Field(
+        None,
+        alias="sliceIdExists",
+        validation_alias=AliasChoices("sliceIdExists", "SliceIdExists", "slice_id_exists"),
+        serialization_alias="sliceIdExists",
+        description="슬라이스 연결 존재 여부",
+    )
     
     # 키 패턴 필터
     key_contains: Optional[str] = Field(None, alias="keyContains", description="키에 포함된 문자열")

--- a/spb_onprem/data/params/data_list.py
+++ b/spb_onprem/data/params/data_list.py
@@ -210,13 +210,6 @@ class DataFilterOptions(CustomBaseModel):
     """
     # ID 및 키 필터
     id_in: Optional[List[str]] = Field(None, alias="idIn", description="특정 데이터 ID 목록 중 하나")
-    slice_id: Optional[str] = Field(
-        None,
-        alias="sliceId",
-        validation_alias=AliasChoices("sliceId", "SliceId", "slice_id"),
-        serialization_alias="sliceId",
-        description="특정 슬라이스 ID에 속한 데이터",
-    )
     slice_id_in: Optional[List[str]] = Field(
         None,
         alias="sliceIdIn",

--- a/spb_onprem/data/params/data_list.py
+++ b/spb_onprem/data/params/data_list.py
@@ -210,20 +210,8 @@ class DataFilterOptions(CustomBaseModel):
     """
     # ID 및 키 필터
     id_in: Optional[List[str]] = Field(None, alias="idIn", description="특정 데이터 ID 목록 중 하나")
-    slice_id_in: Optional[List[str]] = Field(
-        None,
-        alias="sliceIdIn",
-        validation_alias=AliasChoices("sliceIdIn", "SliceIdIn", "slice_id_in"),
-        serialization_alias="sliceIdIn",
-        description="특정 슬라이스 ID 목록에 속한 데이터",
-    )
-    slice_id_all: Optional[List[str]] = Field(
-        None,
-        alias="sliceIdAll",
-        validation_alias=AliasChoices("sliceIdAll", "SliceIdAll", "slice_id_all"),
-        serialization_alias="sliceIdAll",
-        description="모든 슬라이스 ID 목록에 속한 데이터",
-    )
+    slice_id_in: Optional[List[str]] = Field(None, alias="sliceIdIn", description="특정 슬라이스 ID 목록에 속한 데이터")
+    slice_id_all: Optional[List[str]] = Field(None, alias="sliceIdAll", description="모든 슬라이스 ID 목록에 속한 데이터")
     slice_id_exists: Optional[bool] = Field(
         None,
         alias="sliceIdExists",

--- a/tests/data/test_data_filter_params.py
+++ b/tests/data/test_data_filter_params.py
@@ -1,0 +1,45 @@
+from spb_onprem.data.params import DataListFilter, get_data_id_list_params
+
+
+def dump_filter(payload):
+    data_filter = DataListFilter.model_validate(payload)
+    return data_filter.model_dump(by_alias=True, exclude_unset=True)
+
+
+def test_slice_id_exists_false_is_preserved_with_camel_case_alias():
+    payload = {"must": {"sliceIdExists": False}}
+
+    assert dump_filter(payload) == payload
+
+
+def test_slice_id_exists_false_is_preserved_with_legacy_pascal_case_alias():
+    data_filter = DataListFilter.model_validate({"must": {"SliceIdExists": False}})
+
+    assert data_filter.model_dump(by_alias=True, exclude_unset=True) == {
+        "must": {"sliceIdExists": False}
+    }
+
+
+def test_slice_id_filter_fields_are_serialized_for_data_id_list_query():
+    data_filter = DataListFilter.model_validate(
+        {
+            "must": {
+                "sliceId": "slice-1",
+                "sliceIdIn": ["slice-1", "slice-2"],
+                "sliceIdAll": ["slice-1"],
+                "sliceIdExists": False,
+            }
+        }
+    )
+
+    assert get_data_id_list_params(
+        dataset_id="dataset-1",
+        data_filter=data_filter,
+    )["filter"] == {
+        "must": {
+            "sliceId": "slice-1",
+            "sliceIdIn": ["slice-1", "slice-2"],
+            "sliceIdAll": ["slice-1"],
+            "sliceIdExists": False,
+        }
+    }

--- a/tests/data/test_data_filter_params.py
+++ b/tests/data/test_data_filter_params.py
@@ -20,26 +20,23 @@ def test_slice_id_exists_false_is_preserved_with_legacy_pascal_case_alias():
     }
 
 
-def test_slice_id_filter_fields_are_serialized_for_data_id_list_query():
+def test_slice_id_exists_false_is_serialized_for_data_id_list_query():
     data_filter = DataListFilter.model_validate(
-        {
-            "must": {
-                "sliceId": "slice-1",
-                "sliceIdIn": ["slice-1", "slice-2"],
-                "sliceIdAll": ["slice-1"],
-                "sliceIdExists": False,
-            }
-        }
+        {"must": {"sliceIdExists": False}}
     )
 
     assert get_data_id_list_params(
         dataset_id="dataset-1",
         data_filter=data_filter,
-    )["filter"] == {
-        "must": {
-            "sliceId": "slice-1",
-            "sliceIdIn": ["slice-1", "slice-2"],
-            "sliceIdAll": ["slice-1"],
-            "sliceIdExists": False,
-        }
-    }
+    )["filter"] == {"must": {"sliceIdExists": False}}
+
+
+def test_slice_id_field_is_not_serialized_to_avoid_slice_filter_overlap():
+    data_filter = DataListFilter.model_validate(
+        {"must": {"sliceId": "slice-1", "sliceIdExists": False}}
+    )
+
+    assert get_data_id_list_params(
+        dataset_id="dataset-1",
+        data_filter=data_filter,
+    )["filter"] == {"must": {"sliceIdExists": False}}


### PR DESCRIPTION
## Summary
- Add API parity for slice existence data filters in DataFilterOptions.
- Preserve sliceIdExists through Pydantic validation and GraphQL variable serialization, including false values.
- Accept canonical camelCase, legacy PascalCase, and Python snake_case keys for sliceIdExists.
- Keep direct sliceId out of SDK serialization to avoid overlap with the nested filter.slice.id path.
- Add regression coverage for sliceIdExists=false so it is not silently dropped.

## Test Plan
- pipenv run python -m pytest tests/data/test_data_filter_params.py tests/data/test_data_service.py -q
- Result after review update: 10 passed in 0.83s

## Review follow-up
- Removed direct must.sliceId support from the SDK PR per review.
- Pacific FE check: current data filter builder uses sliceIdIn, sliceIdAll, and sliceIdExists for slice filter UI; it does not build direct must.sliceId. Slice page context uses the nested slice path via builder.forSlice(...), i.e. filter.slice.id semantics.
