### PR TITLE
feat: support Data and Slice caption updates

### DIFF
--- a/spb_onprem/data/entities/data.py
+++ b/spb_onprem/data/entities/data.py
@@ -20,6 +20,7 @@ class Data(CustomBaseModel):
     id: Optional[str] = Field(None, description="데이터 고유 식별자")
     dataset_id: Optional[str] = Field(None, alias="datasetId", description="상위 데이터셋 ID")
     key: Optional[str] = Field(None, description="사용자 정의 고유 키")
+    caption: Optional[str] = Field(None, description="데이터 캡션")
     
     # 데이터 타입 및 내용
     type: Optional[DataType] = Field(None, description="데이터 타입 (IMAGE, VIDEO 등)")

--- a/spb_onprem/data/params/update_data.py
+++ b/spb_onprem/data/params/update_data.py
@@ -27,6 +27,15 @@ def update_params(
     annotation_stats: Union[
         Optional[List[DataAnnotationStat]],
         UndefinedType
+    ] = Undefined,
+    caption: Union[
+        Optional[str],
+        UndefinedType
+    ] = Undefined,
+    expected_caption: Union[
+        UndefinedType,
+        None,
+        str
     ] = Undefined
 ):
     """Make the variables for the updateData query.
@@ -37,6 +46,8 @@ def update_params(
         key (str): The key of the data.
         meta (List[DataMeta]): The meta of the data.
         annotation_stats (List[DataAnnotationStat]): The annotation stats of the data.
+        caption (str): The caption of the data.
+        expected_caption (str): The expected caption of the data.
     """
     variables = {
         "dataset_id": dataset_id,
@@ -62,5 +73,11 @@ def update_params(
         variables["annotation_stats"] = [
             stat.model_dump(by_alias=True, exclude_unset=True) for stat in annotation_stats
         ] if annotation_stats is not None else None
+
+    if caption is not Undefined:
+        variables["caption"] = caption
+
+    if expected_caption is not Undefined:
+        variables["expectedCaption"] = expected_caption
 
     return variables

--- a/spb_onprem/data/queries.py
+++ b/spb_onprem/data/queries.py
@@ -43,6 +43,7 @@ class Schemas:
         id
         datasetId
         key
+        caption
         type
         scene {
             id
@@ -189,7 +190,8 @@ class Queries():
                 $data_id: ID!,
                 $key: String,
                 $meta: [DataMetaInput!],
-                $annotation_stats: [AnnotationStatInput!]
+                $annotation_stats: [AnnotationStatInput!],
+                $caption: String
             ) {{
             updateData(
                 datasetId: $dataset_id,
@@ -197,7 +199,39 @@ class Queries():
                 key: $key,
                 meta: $meta,
                 annotationStats: $annotation_stats,
-            ) 
+                caption: $caption,
+            )
+                {{
+                    {Schemas.DATA}
+                }}
+            }}
+        ''',
+        "variables": update_params,
+    }
+
+    # Guarded variant: only used when expected_caption is provided, so the
+    # unguarded UPDATE query never carries an undefined $expectedCaption.
+    UPDATE_WITH_EXPECTED_CAPTION = {
+        "name": "updateData",
+        "query": f'''
+            mutation updateData(
+                $dataset_id: ID!,
+                $data_id: ID!,
+                $key: String,
+                $meta: [DataMetaInput!],
+                $annotation_stats: [AnnotationStatInput!],
+                $caption: String,
+                $expectedCaption: String
+            ) {{
+            updateData(
+                datasetId: $dataset_id,
+                id: $data_id,
+                key: $key,
+                meta: $meta,
+                annotationStats: $annotation_stats,
+                caption: $caption,
+                expectedCaption: $expectedCaption,
+            )
                 {{
                     {Schemas.DATA}
                 }}

--- a/spb_onprem/data/service.py
+++ b/spb_onprem/data/service.py
@@ -227,6 +227,15 @@ class DataService(BaseService):
             Optional[List[DataAnnotationStat]],
             UndefinedType,
         ] = Undefined,
+        caption: Union[
+            Optional[str],
+            UndefinedType,
+        ] = Undefined,
+        expected_caption: Union[
+            UndefinedType,
+            None,
+            str,
+        ] = Undefined,
     ):
         """Update a data.
 
@@ -235,18 +244,28 @@ class DataService(BaseService):
             data_id (str): The data id.
             key (Union[str, UndefinedType], optional): The key of the data. Defaults to Undefined.
             meta (Union[List[DataMeta], UndefinedType], optional): The meta data. Defaults to Undefined.
+            caption (Union[Optional[str], UndefinedType], optional): The caption of the data. Defaults to Undefined.
+            expected_caption (Union[UndefinedType, None, str], optional): The expected caption of the data.
+                Omitted when Undefined, sent as null when None. Defaults to Undefined.
 
         Returns:
             Data: The updated data.
         """
+        query = (
+            Queries.UPDATE_WITH_EXPECTED_CAPTION
+            if expected_caption is not Undefined
+            else Queries.UPDATE
+        )
         response = self.request_gql(
-            Queries.UPDATE,
-            variables=Queries.UPDATE["variables"](
+            query,
+            variables=query["variables"](
                 dataset_id=dataset_id,
                 data_id=data_id,
                 key=key,
                 meta=meta,
                 annotation_stats=annotation_stats,
+                caption=caption,
+                expected_caption=expected_caption,
             )
         )
         data = Data.model_validate(response)

--- a/spb_onprem/slices/entities/slice.py
+++ b/spb_onprem/slices/entities/slice.py
@@ -13,6 +13,7 @@ class Slice(CustomBaseModel):
     dataset_id: Optional[str] = Field(None, alias="datasetId", description="상위 데이터셋 ID")
     name: Optional[str] = Field(None, description="슬라이스 이름")
     description: Optional[str] = Field(None, description="슬라이스 설명")
+    caption: Optional[str] = Field(None, description="슬라이스 캡션")
     is_pinned: Optional[bool] = Field(None, alias="isPinned", description="즐겨찾기 고정 여부")
     created_at: Optional[str] = Field(None, alias="createdAt", description="생성일시 (ISO 8601)")
     created_by: Optional[str] = Field(None, alias="createdBy", description="생성자")

--- a/spb_onprem/slices/params/update_slice.py
+++ b/spb_onprem/slices/params/update_slice.py
@@ -14,7 +14,17 @@ def update_slice_params(
     slice_description: Union[
         UndefinedType,
         str
-    ] = Undefined
+    ] = Undefined,
+    slice_caption: Union[
+        UndefinedType,
+        None,
+        str
+    ] = Undefined,
+    expected_caption: Union[
+        UndefinedType,
+        None,
+        str
+    ] = Undefined,
 ):
     """Update slice parameters.
     
@@ -23,6 +33,8 @@ def update_slice_params(
         slice_id (str): The ID of the slice to update.
         slice_name (Optional[str]): The name of the slice to update.
         slice_description (Optional[str]): The description of the slice to update.
+        slice_caption (Union[UndefinedType, None, str]): The aggregate caption to update.
+        expected_caption (Union[UndefinedType, None, str]): The expected aggregate caption.
         
     Returns:
         dict: Parameters for slice update
@@ -41,5 +53,9 @@ def update_slice_params(
         variables["name"] = slice_name
     if slice_description is not Undefined:
         variables["description"] = slice_description
+    if slice_caption is not Undefined:
+        variables["caption"] = slice_caption
+    if expected_caption is not Undefined:
+        variables["expectedCaption"] = expected_caption
 
     return variables

--- a/spb_onprem/slices/queries.py
+++ b/spb_onprem/slices/queries.py
@@ -14,6 +14,7 @@ class Schemas:
         slices {
             id
             name
+            caption
         }
         next
         totalCount
@@ -24,6 +25,7 @@ class Schemas:
         datasetId
         name
         description
+        caption
         isPinned
         createdAt
         createdBy
@@ -106,13 +108,41 @@ class Queries:
                 $dataset_id: String!,
                 $id: ID!,
                 $name: String,
-                $description: String
+                $description: String,
+                $caption: String
             ) {{
                 updateSlice(
                     datasetId: $dataset_id,
                     id: $id,
                     name: $name,
-                    description: $description
+                    description: $description,
+                    caption: $caption
+                ) {{
+                    {Schemas.SLICE}
+                }}
+            }}
+        ''',
+        "variables": update_slice_params,
+    }
+
+    UPDATE_SLICE_WITH_EXPECTED_CAPTION = {
+        "name": "updateSlice",
+        "query": f'''
+            mutation updateSlice(
+                $dataset_id: String!,
+                $id: ID!,
+                $name: String,
+                $description: String,
+                $caption: String,
+                $expectedCaption: String
+            ) {{
+                updateSlice(
+                    datasetId: $dataset_id,
+                    id: $id,
+                    name: $name,
+                    description: $description,
+                    caption: $caption,
+                    expectedCaption: $expectedCaption
                 ) {{
                     {Schemas.SLICE}
                 }}

--- a/spb_onprem/slices/service.py
+++ b/spb_onprem/slices/service.py
@@ -162,6 +162,16 @@ class SliceService(BaseService):
             UndefinedType,
             str
         ] = Undefined,
+        caption: Union[
+            UndefinedType,
+            None,
+            str
+        ] = Undefined,
+        expected_caption: Union[
+            UndefinedType,
+            None,
+            str
+        ] = Undefined,
     ):
         """Update a slice.
         
@@ -170,20 +180,29 @@ class SliceService(BaseService):
             slice_id (str): The ID of the slice to update.
             name (Optional[str]): The name of the slice to update.
             description (Optional[str]): The description of the slice to update.
+            caption (Union[UndefinedType, None, str]): The aggregate caption to update.
+            expected_caption (Union[UndefinedType, None, str]): The expected aggregate caption.
         
         Returns:
             Slice: The updated slice object.
         """
+        query = (
+            Queries.UPDATE_SLICE_WITH_EXPECTED_CAPTION
+            if expected_caption is not Undefined
+            else Queries.UPDATE_SLICE
+        )
         response = self.request_gql(
-            Queries.UPDATE_SLICE,
-            Queries.UPDATE_SLICE["variables"](
+            query,
+            query["variables"](
                 dataset_id=dataset_id,
                 slice_id=slice_id,
                 slice_name=name,
-                slice_description=description
+                slice_description=description,
+                slice_caption=caption,
+                expected_caption=expected_caption,
             )
         )
-        slice_dict = response.get("updateSlice", {})
+        slice_dict = response.get("updateSlice", response)
         return Slice.model_validate(slice_dict)
 
     def delete_slice(

--- a/tests/data/test_update_data_caption.py
+++ b/tests/data/test_update_data_caption.py
@@ -1,0 +1,297 @@
+"""Chicago-style TDD tests for caption support in update_data.
+
+Real params/query/entity objects are used throughout; only the
+BaseService network boundary (request_gql) is mocked.
+"""
+from unittest.mock import Mock
+
+from spb_onprem.data.service import DataService
+from spb_onprem.data.queries import Queries, Schemas
+from spb_onprem.data.params.update_data import update_params
+from spb_onprem.data.entities import Data
+
+
+class TestUpdateParamsCaption:
+    """update_params must follow Undefined/None/value semantics for caption."""
+
+    def test_caption_undefined_is_omitted(self):
+        variables = update_params(
+            dataset_id="dataset-123",
+            data_id="data-456",
+        )
+        assert "caption" not in variables
+
+    def test_caption_none_is_sent_as_null(self):
+        variables = update_params(
+            dataset_id="dataset-123",
+            data_id="data-456",
+            caption=None,
+        )
+        assert "caption" in variables
+        assert variables["caption"] is None
+
+    def test_caption_string_is_sent_exactly(self):
+        caption = "a synthetic caption for a test image"
+        variables = update_params(
+            dataset_id="dataset-123",
+            data_id="data-456",
+            caption=caption,
+        )
+        assert variables["caption"] == caption
+
+
+class TestUpdateParamsExpectedCaption:
+    """update_params must follow Undefined/None/value semantics for expected_caption."""
+
+    def test_expected_caption_undefined_is_omitted(self):
+        variables = update_params(
+            dataset_id="dataset-123",
+            data_id="data-456",
+        )
+        assert "expectedCaption" not in variables
+
+    def test_expected_caption_none_is_sent_as_null(self):
+        variables = update_params(
+            dataset_id="dataset-123",
+            data_id="data-456",
+            expected_caption=None,
+        )
+        assert "expectedCaption" in variables
+        assert variables["expectedCaption"] is None
+
+    def test_expected_caption_empty_string_is_preserved(self):
+        variables = update_params(
+            dataset_id="dataset-123",
+            data_id="data-456",
+            expected_caption="",
+        )
+        assert variables["expectedCaption"] == ""
+
+    def test_expected_caption_string_is_sent_exactly(self):
+        expected_caption = "a synthetic expected caption"
+        variables = update_params(
+            dataset_id="dataset-123",
+            data_id="data-456",
+            expected_caption=expected_caption,
+        )
+        assert variables["expectedCaption"] == expected_caption
+
+
+class TestUpdateQueryCaption:
+    """The updateData GraphQL document must carry the caption variable."""
+
+    def test_update_query_declares_caption_variable(self):
+        query = Queries.UPDATE["query"]
+        assert "$caption: String" in query
+        assert "caption: $caption" in query
+
+    def test_data_schema_selects_caption_field(self):
+        assert "caption" in Schemas.DATA.split()
+
+
+class TestUpdateQueryExpectedCaption:
+    """expectedCaption only appears in the guarded query variant."""
+
+    def test_unguarded_update_query_omits_expected_caption(self):
+        query = Queries.UPDATE["query"]
+        assert "$expectedCaption" not in query
+        assert "expectedCaption" not in query
+
+    def test_guarded_update_query_declares_expected_caption_variable(self):
+        query = Queries.UPDATE_WITH_EXPECTED_CAPTION["query"]
+        assert "$expectedCaption: String" in query
+        assert "expectedCaption: $expectedCaption" in query
+
+    def test_guarded_update_query_keeps_caption_argument(self):
+        query = Queries.UPDATE_WITH_EXPECTED_CAPTION["query"]
+        assert "$caption: String" in query
+        assert "caption: $caption" in query
+
+    def test_guarded_update_query_shares_name_and_params(self):
+        assert Queries.UPDATE_WITH_EXPECTED_CAPTION["name"] == "updateData"
+        assert Queries.UPDATE_WITH_EXPECTED_CAPTION["variables"] is update_params
+
+
+class TestDataEntityCaption:
+    """The Data entity must map the caption field from a response."""
+
+    def test_data_maps_caption(self):
+        data = Data.model_validate({
+            "id": "data-456",
+            "datasetId": "dataset-123",
+            "caption": "a synthetic caption",
+        })
+        assert data.caption == "a synthetic caption"
+
+    def test_data_caption_defaults_to_none(self):
+        data = Data.model_validate({
+            "id": "data-456",
+            "datasetId": "dataset-123",
+        })
+        assert data.caption is None
+
+
+class TestDataServiceUpdateDataCaption:
+    """DataService.update_data must pass caption through to the request."""
+
+    def setup_method(self):
+        self.data_service = DataService()
+        self.data_service.request_gql = Mock()
+
+    def test_update_data_sends_caption(self):
+        self.data_service.request_gql.return_value = {
+            "id": "data-456",
+            "datasetId": "dataset-123",
+            "caption": "a synthetic caption",
+        }
+
+        result = self.data_service.update_data(
+            dataset_id="dataset-123",
+            data_id="data-456",
+            caption="a synthetic caption",
+        )
+
+        _, kwargs = self.data_service.request_gql.call_args
+        variables = kwargs.get("variables") or self.data_service.request_gql.call_args[0][1]
+        assert variables["caption"] == "a synthetic caption"
+        assert result.caption == "a synthetic caption"
+
+    def test_update_data_caption_none_sends_null(self):
+        self.data_service.request_gql.return_value = {
+            "id": "data-456",
+            "datasetId": "dataset-123",
+        }
+
+        self.data_service.update_data(
+            dataset_id="dataset-123",
+            data_id="data-456",
+            caption=None,
+        )
+
+        _, kwargs = self.data_service.request_gql.call_args
+        variables = kwargs.get("variables") or self.data_service.request_gql.call_args[0][1]
+        assert "caption" in variables
+        assert variables["caption"] is None
+
+    def test_update_data_without_caption_stays_compatible(self):
+        """Old call sites that never pass caption must be unaffected."""
+        self.data_service.request_gql.return_value = {
+            "id": "data-456",
+            "datasetId": "dataset-123",
+            "key": "new-key",
+        }
+
+        result = self.data_service.update_data(
+            dataset_id="dataset-123",
+            data_id="data-456",
+            key="new-key",
+        )
+
+        args, kwargs = self.data_service.request_gql.call_args
+        variables = kwargs.get("variables") or self.data_service.request_gql.call_args[0][1]
+        assert variables == {
+            "dataset_id": "dataset-123",
+            "data_id": "data-456",
+            "key": "new-key",
+        }
+        assert args[0] is Queries.UPDATE
+        assert result.key == "new-key"
+
+
+class TestDataServiceUpdateDataExpectedCaption:
+    """DataService.update_data must route expected_caption through the guarded query."""
+
+    def setup_method(self):
+        self.data_service = DataService()
+        self.data_service.request_gql = Mock()
+
+    def _sent(self):
+        args, kwargs = self.data_service.request_gql.call_args
+        variables = kwargs.get("variables") or args[1]
+        return args[0], variables
+
+    def test_expected_caption_undefined_uses_unguarded_query_and_omits_variable(self):
+        self.data_service.request_gql.return_value = {
+            "id": "data-456",
+            "datasetId": "dataset-123",
+        }
+
+        self.data_service.update_data(
+            dataset_id="dataset-123",
+            data_id="data-456",
+            caption="a synthetic caption",
+        )
+
+        query, variables = self._sent()
+        assert query is Queries.UPDATE
+        assert variables == {
+            "dataset_id": "dataset-123",
+            "data_id": "data-456",
+            "caption": "a synthetic caption",
+        }
+
+    def test_expected_caption_none_uses_guarded_query_and_sends_null(self):
+        self.data_service.request_gql.return_value = {
+            "id": "data-456",
+            "datasetId": "dataset-123",
+        }
+
+        self.data_service.update_data(
+            dataset_id="dataset-123",
+            data_id="data-456",
+            expected_caption=None,
+        )
+
+        query, variables = self._sent()
+        assert query is Queries.UPDATE_WITH_EXPECTED_CAPTION
+        assert variables == {
+            "dataset_id": "dataset-123",
+            "data_id": "data-456",
+            "expectedCaption": None,
+        }
+
+    def test_expected_caption_empty_string_uses_guarded_query(self):
+        self.data_service.request_gql.return_value = {
+            "id": "data-456",
+            "datasetId": "dataset-123",
+        }
+
+        self.data_service.update_data(
+            dataset_id="dataset-123",
+            data_id="data-456",
+            caption="a synthetic caption",
+            expected_caption="",
+        )
+
+        query, variables = self._sent()
+        assert query is Queries.UPDATE_WITH_EXPECTED_CAPTION
+        assert variables == {
+            "dataset_id": "dataset-123",
+            "data_id": "data-456",
+            "caption": "a synthetic caption",
+            "expectedCaption": "",
+        }
+
+    def test_expected_caption_string_uses_guarded_query_and_sends_value(self):
+        self.data_service.request_gql.return_value = {
+            "id": "data-456",
+            "datasetId": "dataset-123",
+            "caption": "a synthetic caption",
+        }
+
+        result = self.data_service.update_data(
+            dataset_id="dataset-123",
+            data_id="data-456",
+            caption="a synthetic caption",
+            expected_caption="a synthetic expected caption",
+        )
+
+        query, variables = self._sent()
+        assert query is Queries.UPDATE_WITH_EXPECTED_CAPTION
+        assert variables == {
+            "dataset_id": "dataset-123",
+            "data_id": "data-456",
+            "caption": "a synthetic caption",
+            "expectedCaption": "a synthetic expected caption",
+        }
+        assert result.caption == "a synthetic caption"

--- a/tests/slices/test_update_slice_caption.py
+++ b/tests/slices/test_update_slice_caption.py
@@ -1,0 +1,345 @@
+"""Behavioral tests for canonical Slice.caption read/write support.
+
+Real params, query, entity, and service objects are used. Only the
+BaseService HTTP/GraphQL transport boundary is stubbed.
+"""
+from unittest.mock import Mock
+
+from spb_onprem.slices.entities import Slice
+from spb_onprem.slices.params.update_slice import update_slice_params
+from spb_onprem.slices.queries import Queries, Schemas
+from spb_onprem.slices.service import SliceService
+
+
+class TestSliceCaptionEntity:
+    def test_slice_deserializes_caption(self):
+        slice_obj = Slice.model_validate({
+            "id": "slice-456",
+            "datasetId": "dataset-123",
+            "caption": "one aggregate caption",
+        })
+
+        assert slice_obj.caption == "one aggregate caption"
+
+    def test_slice_caption_defaults_to_none(self):
+        slice_obj = Slice.model_validate({
+            "id": "slice-456",
+            "datasetId": "dataset-123",
+        })
+
+        assert slice_obj.caption is None
+
+
+class TestSliceCaptionQuery:
+    def test_slice_schema_selects_caption(self):
+        assert "caption" in Schemas.SLICE.split()
+
+    def test_update_query_declares_and_sends_caption(self):
+        query = Queries.UPDATE_SLICE["query"]
+
+        assert "$caption: String" in query
+        assert "caption: $caption" in query
+        assert Queries.UPDATE_SLICE["variables"] is update_slice_params
+
+    def test_unguarded_update_query_omits_expected_caption(self):
+        query = Queries.UPDATE_SLICE["query"]
+
+        assert "$expectedCaption" not in query
+        assert "expectedCaption" not in query
+
+    def test_guarded_update_query_declares_and_sends_expected_caption(self):
+        query = Queries.UPDATE_SLICE_WITH_EXPECTED_CAPTION["query"]
+
+        assert "$expectedCaption: String" in query
+        assert "expectedCaption: $expectedCaption" in query
+        assert Queries.UPDATE_SLICE_WITH_EXPECTED_CAPTION["name"] == "updateSlice"
+        assert Queries.UPDATE_SLICE_WITH_EXPECTED_CAPTION["variables"] is update_slice_params
+
+
+class TestUpdateSliceCaptionParams:
+    def test_undefined_caption_is_omitted(self):
+        variables = update_slice_params(
+            dataset_id="dataset-123",
+            slice_id="slice-456",
+        )
+
+        assert "caption" not in variables
+
+    def test_none_caption_is_sent_as_null(self):
+        variables = update_slice_params(
+            dataset_id="dataset-123",
+            slice_id="slice-456",
+            slice_caption=None,
+        )
+
+        assert "caption" in variables
+        assert variables["caption"] is None
+
+    def test_string_caption_is_sent_exactly(self):
+        variables = update_slice_params(
+            dataset_id="dataset-123",
+            slice_id="slice-456",
+            slice_caption="one aggregate caption",
+        )
+
+        assert variables["caption"] == "one aggregate caption"
+
+    def test_undefined_expected_caption_is_omitted(self):
+        variables = update_slice_params(
+            dataset_id="dataset-123",
+            slice_id="slice-456",
+        )
+
+        assert "expectedCaption" not in variables
+
+    def test_none_expected_caption_is_sent_as_null(self):
+        variables = update_slice_params(
+            dataset_id="dataset-123",
+            slice_id="slice-456",
+            expected_caption=None,
+        )
+
+        assert "expectedCaption" in variables
+        assert variables["expectedCaption"] is None
+
+    def test_empty_expected_caption_is_preserved(self):
+        variables = update_slice_params(
+            dataset_id="dataset-123",
+            slice_id="slice-456",
+            expected_caption="",
+        )
+
+        assert variables["expectedCaption"] == ""
+
+    def test_string_expected_caption_is_sent_exactly(self):
+        variables = update_slice_params(
+            dataset_id="dataset-123",
+            slice_id="slice-456",
+            expected_caption="observed caption",
+        )
+
+        assert variables["expectedCaption"] == "observed caption"
+
+
+class TestSliceServiceCaption:
+    def setup_method(self):
+        self.slice_service = SliceService()
+        self.slice_service.request_gql = Mock()
+
+    def _sent_variables(self):
+        args, kwargs = self.slice_service.request_gql.call_args
+        return kwargs.get("variables") or args[1]
+
+    def _sent_query(self):
+        args, _ = self.slice_service.request_gql.call_args
+        return args[0]
+
+    def test_get_slice_returns_caption(self):
+        self.slice_service.request_gql.return_value = {
+            "id": "slice-456",
+            "datasetId": "dataset-123",
+            "caption": "one aggregate caption",
+        }
+
+        result = self.slice_service.get_slice(
+            dataset_id="dataset-123",
+            slice_id="slice-456",
+        )
+
+        assert result.caption == "one aggregate caption"
+
+    def test_get_slices_returns_caption_across_the_http_graphql_boundary(self):
+        class ProjectingGraphQLResponse:
+            status_code = 200
+            elapsed = None
+
+            def __init__(self, payload):
+                slice_payload = {
+                    "id": "slice-456",
+                    "name": "training",
+                }
+                if "caption" in payload["query"].split():
+                    slice_payload["caption"] = "one aggregate caption"
+                self._body = {
+                    "data": {
+                        "slices": {
+                            "slices": [slice_payload],
+                            "next": None,
+                            "totalCount": 1,
+                        },
+                    },
+                }
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return self._body
+
+        class GraphQLSessionFake:
+            def post(self, _endpoint, json, _headers=None, **kwargs):
+                headers = kwargs.get("headers", _headers)
+                assert headers is not None
+                return ProjectingGraphQLResponse(json)
+
+            def close(self):
+                return None
+
+        self.slice_service.request_gql = SliceService.request_gql.__get__(
+            self.slice_service,
+            SliceService,
+        )
+        self.slice_service.requests_retry_session = lambda: GraphQLSessionFake()
+
+        slices, next_cursor, total_count = self.slice_service.get_slices(
+            dataset_id="dataset-123",
+        )
+
+        assert slices[0].caption == "one aggregate caption"
+        assert next_cursor is None
+        assert total_count == 1
+
+    def test_update_slice_sends_and_returns_caption(self):
+        self.slice_service.request_gql.return_value = {
+            "id": "slice-456",
+            "datasetId": "dataset-123",
+            "caption": "one aggregate caption",
+        }
+
+        result = self.slice_service.update_slice(
+            dataset_id="dataset-123",
+            slice_id="slice-456",
+            caption="one aggregate caption",
+        )
+
+        assert self._sent_variables()["caption"] == "one aggregate caption"
+        assert result.caption == "one aggregate caption"
+
+    def test_update_slice_none_sends_null(self):
+        self.slice_service.request_gql.return_value = {
+            "id": "slice-456",
+            "datasetId": "dataset-123",
+        }
+
+        self.slice_service.update_slice(
+            dataset_id="dataset-123",
+            slice_id="slice-456",
+            caption=None,
+        )
+
+        variables = self._sent_variables()
+        assert "caption" in variables
+        assert variables["caption"] is None
+
+    def test_update_slice_without_caption_stays_compatible(self):
+        self.slice_service.request_gql.return_value = {
+            "updateSlice": {
+                "id": "slice-456",
+                "datasetId": "dataset-123",
+                "name": "renamed",
+            },
+        }
+
+        result = self.slice_service.update_slice(
+            dataset_id="dataset-123",
+            slice_id="slice-456",
+            name="renamed",
+        )
+
+        assert self._sent_variables() == {
+            "dataset_id": "dataset-123",
+            "id": "slice-456",
+            "name": "renamed",
+        }
+        assert result.name == "renamed"
+
+    def test_omitted_expected_caption_uses_unguarded_query(self):
+        self.slice_service.request_gql.return_value = {
+            "id": "slice-456",
+            "datasetId": "dataset-123",
+        }
+
+        self.slice_service.update_slice(
+            dataset_id="dataset-123",
+            slice_id="slice-456",
+            caption="next caption",
+        )
+
+        assert self._sent_query() is Queries.UPDATE_SLICE
+        assert "expectedCaption" not in self._sent_variables()
+
+    def test_none_expected_caption_uses_guarded_query_and_sends_null(self):
+        self.slice_service.request_gql.return_value = {
+            "id": "slice-456",
+            "datasetId": "dataset-123",
+        }
+
+        self.slice_service.update_slice(
+            dataset_id="dataset-123",
+            slice_id="slice-456",
+            caption="next caption",
+            expected_caption=None,
+        )
+
+        assert self._sent_query() is Queries.UPDATE_SLICE_WITH_EXPECTED_CAPTION
+        assert self._sent_variables()["expectedCaption"] is None
+
+    def test_empty_expected_caption_uses_guarded_query(self):
+        self.slice_service.request_gql.return_value = {
+            "id": "slice-456",
+            "datasetId": "dataset-123",
+        }
+
+        self.slice_service.update_slice(
+            dataset_id="dataset-123",
+            slice_id="slice-456",
+            caption="next caption",
+            expected_caption="",
+        )
+
+        assert self._sent_query() is Queries.UPDATE_SLICE_WITH_EXPECTED_CAPTION
+        assert self._sent_variables()["expectedCaption"] == ""
+
+    def test_value_expected_caption_uses_guarded_query(self):
+        self.slice_service.request_gql.return_value = {
+            "id": "slice-456",
+            "datasetId": "dataset-123",
+            "caption": "next caption",
+        }
+
+        result = self.slice_service.update_slice(
+            dataset_id="dataset-123",
+            slice_id="slice-456",
+            caption="next caption",
+            expected_caption="observed caption",
+        )
+
+        assert self._sent_query() is Queries.UPDATE_SLICE_WITH_EXPECTED_CAPTION
+        assert self._sent_variables()["expectedCaption"] == "observed caption"
+        assert result.caption == "next caption"
+
+    def test_existing_positional_arguments_keep_their_meaning(self):
+        self.slice_service.request_gql.return_value = {
+            "id": "slice-456",
+            "datasetId": "dataset-123",
+            "name": "renamed",
+            "description": "updated description",
+            "caption": "next caption",
+        }
+
+        self.slice_service.update_slice(
+            "dataset-123",
+            "slice-456",
+            "renamed",
+            "updated description",
+            "next caption",
+        )
+
+        assert self._sent_query() is Queries.UPDATE_SLICE
+        assert self._sent_variables() == {
+            "dataset_id": "dataset-123",
+            "id": "slice-456",
+            "name": "renamed",
+            "description": "updated description",
+            "caption": "next caption",
+        }


### PR DESCRIPTION
## Summary
- expose nullable `caption` on Data and Slice SDK entities
- add optimistic caption update parameters and service methods
- update GraphQL queries/mutations for caption read/write
- add focused Data and Slice caption contract tests

## Verification
- isolated virtualenv: `python -m pytest -q tests/data/test_update_data_caption.py tests/slices/test_update_slice_caption.py` (45 passed)
- `git diff --check origin/main...HEAD`

## Integration
Part of the VLM caption flow. Zenith supplies the GraphQL contract, Airflow routes scoped Data/Slice targets, and the GPU caption app uses this SDK for read/write and read-back verification. Pacific UI is intentionally excluded.