### PR TITLE
fix: bind exception in BaseService.request ValueError handler

### DIFF
--- a/spb_onprem/base_service.py
+++ b/spb_onprem/base_service.py
@@ -225,7 +225,7 @@ class BaseService():
         except requests.exceptions.RequestException as e:
             print(f"An error occurred during the HTTP request: {str(e)}")
             raise BadRequestError(f"HTTP request failed: {str(e)}") from e
-        except ValueError:
+        except ValueError as e:
             raise BadRequestParameterError("Failed to parse the HTTP response as JSON.") from e
         except Exception as e:
             raise RequestError(f"An error occurred while processing the HTTP response: {str(e)}") from e

--- a/tests/test_base_service.py
+++ b/tests/test_base_service.py
@@ -1,0 +1,58 @@
+import pytest
+from unittest.mock import Mock, patch
+
+import requests
+
+from spb_onprem.base_service import BaseService
+from spb_onprem.exceptions import (
+    BadRequestParameterError,
+    BadRequestError,
+    RequestError,
+)
+
+
+class TestBaseServiceRequestErrorHandling:
+    """Exception translation in BaseService.request().
+
+    request() is inherited by the contents, diagnoses, models, inferences and
+    reports services, so the exceptions it surfaces are part of their contract.
+    """
+
+    def setup_method(self):
+        self.service = BaseService()
+
+    @staticmethod
+    def _session_raising(exc):
+        session = Mock()
+        session.request.side_effect = exc
+        return session
+
+    def test_value_error_raises_bad_request_parameter_error(self):
+        """A ValueError from the underlying request surfaces as BadRequestParameterError."""
+        session = self._session_raising(ValueError("bad value"))
+        with patch.object(BaseService, "requests_retry_session", return_value=session):
+            with pytest.raises(BadRequestParameterError):
+                self.service.request("GET", "http://example.com", headers={})
+
+    def test_value_error_preserves_original_cause(self):
+        """The BadRequestParameterError chains the original ValueError via `from e`."""
+        original = ValueError("bad value")
+        session = self._session_raising(original)
+        with patch.object(BaseService, "requests_retry_session", return_value=session):
+            with pytest.raises(BadRequestParameterError) as excinfo:
+                self.service.request("GET", "http://example.com", headers={})
+        assert excinfo.value.__cause__ is original
+
+    def test_request_exception_raises_bad_request_error(self):
+        """A requests RequestException still surfaces as BadRequestError."""
+        session = self._session_raising(requests.exceptions.ConnectionError("boom"))
+        with patch.object(BaseService, "requests_retry_session", return_value=session):
+            with pytest.raises(BadRequestError):
+                self.service.request("GET", "http://example.com", headers={})
+
+    def test_unexpected_exception_raises_request_error(self):
+        """Any other exception still surfaces as RequestError."""
+        session = self._session_raising(RuntimeError("boom"))
+        with patch.object(BaseService, "requests_retry_session", return_value=session):
+            with pytest.raises(RequestError):
+                self.service.request("GET", "http://example.com", headers={})


### PR DESCRIPTION
This PR proposes binding the exception in `BaseService.request()`'s `ValueError` handler so a failed request raises the intended `BadRequestParameterError` instead of crashing with `UnboundLocalError`. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/259. You can sign in with your GitHub ID to claim ownership of the project.

## What this fixes

`BaseService.request()` in `spb_onprem/base_service.py` is inherited by the contents, diagnoses, models, inferences and reports services, so the exceptions it raises are part of their contract. Its handler translates low-level failures into the SDK's own exception types, but the middle branch does not bind the exception it then references:

```python
except requests.exceptions.RequestException as e:
    ...
    raise BadRequestError(...) from e
except ValueError:                     # note: no `as e`
    raise BadRequestParameterError("Failed to parse the HTTP response as JSON.") from e
except Exception as e:
    raise RequestError(...) from e
```

Because the clause is `except ValueError:` rather than `except ValueError as e:`, the trailing `from e` refers to a name that is unbound in that branch. So whenever a `ValueError` is raised inside `request()`, callers do not receive the documented `BadRequestParameterError` — they receive an `UnboundLocalError: cannot access local variable 'e'` that discards the original cause.

The fix is one line: bind the exception with `as e`, matching the two sibling handlers on either side of it.

## How it was verified

Reproduced on the current `main` (HEAD `e2ece01`):

```python
from unittest.mock import Mock, patch
from spb_onprem.base_service import BaseService

svc = BaseService()
session = Mock(); session.request.side_effect = ValueError("boom")
with patch.object(BaseService, "requests_retry_session", return_value=session):
    svc.request("GET", "http://example.com", headers={})
# before this change: UnboundLocalError: cannot access local variable 'e'
# after this change:  BadRequestParameterError: Failed to parse the HTTP response as JSON.
```

This change adds `tests/test_base_service.py` with four cases covering `request()`'s error translation. The two `ValueError` cases fail on the current tree (`UnboundLocalError`) and pass after the fix; the `RequestException` and generic-`Exception` cases pin the surrounding handlers so they keep raising `BadRequestError` and `RequestError`.

Full suite before this change: 45 passed, 5 skipped. After: 49 passed, 5 skipped — no new failures. The run also reports one pre-existing, unrelated collection error under `tests/trainingreports/` that this change does not touch. Command used (your CI invocation): `pytest tests/ -v --ignore=tests/activities/real_test.py --ignore=tests/exports/real_test.py`.

Backward compatibility: the change only affects which exception surfaces on an already-failing path — it restores the documented `BadRequestParameterError` (a `BaseSDKError` subclass) and preserves the original cause via `__cause__`. No public signatures change and no success-path behavior changes.

## How this was managed

We imported this repository's pull-request history into a live agile board (86 stories) and tracked this fix on it as a single story:

- Story: https://eastagiletracker.com/projects/259/stories/151948
- Board: https://eastagiletracker.com/projects/259

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
